### PR TITLE
[WPT sync task] Update URLs that targeted tidoust/reffy-reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
 script:
   - |
     if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
-      node wpt-sync/sync.js --wpt-dir wpt --build-url https://travis-ci.org/tidoust/reffy-reports/builds/$TRAVIS_BUILD_ID
+      node wpt-sync/sync.js --wpt-dir wpt --build-url https://travis-ci.org/w3c/webref/builds/$TRAVIS_BUILD_ID
     else
       node wpt-sync/sync.js --wpt-dir wpt --dry-run
     fi

--- a/wpt-sync/sync.js
+++ b/wpt-sync/sync.js
@@ -15,7 +15,7 @@ If additional changes are needed, please manually create another PR based on thi
 See the [README](https://github.com/web-platform-tests/wpt/blob/master/interfaces/README.md) for how the IDL files in this directory are used.`
 
 const CSSOM_PREAMBLE = `// GENERATED PREAMBLE - DO NOT EDIT
-// This preamble was added by reffy-reports for web-platform-tests.
+// This preamble was added by webref for web-platform-tests.
 // CSSOMString is an implementation-defined type of either DOMString or
 // USVString in CSSOM: https://drafts.csswg.org/cssom/#cssomstring-type
 // For web-platform-tests, use DOMString because USVString has additional
@@ -44,7 +44,7 @@ function createLocalBranches(srcDir, dstDir, makeCommitMessage) {
 
     // Returns the sha of any commit not mentioning reffy-reports touching
     // `file` in `dstDir` since `since`, if any, and a falsy value otherwise.
-    // See https://github.com/tidoust/reffy-reports/issues/25 for background.
+    // See https://github.com/w3c/webref/issues/25 for background.
     function lastManualCommitSince(file, since) {
         return git(`log -1 --since=${since} --grep reffy-reports --invert-grep --format=%h -- ${file}`).trim();
     }
@@ -294,7 +294,7 @@ async function main() {
         if (extras && extras.length) {
             message += extras.join('\n') + '\n\n';
         }
-        message += `Source: https://github.com/tidoust/reffy-reports/blob/${buildSha}/ed/idl/${file}\n`;
+        message += `Source: https://github.com/w3c/webref/blob/${buildSha}/ed/idl/${file}\n`;
         if (buildUrl) {
             message += `Build: ${buildUrl}\n`;
         }


### PR DESCRIPTION
See #52.

@foolip, the update does not rename the branches that created, which would continue to be named `reffy-reports/xxx`. Or would you prefer to rename them as well?