### PR TITLE
Update references to Reffy following transfer to w3c

### DIFF
--- a/.github/workflows/update-ed.yml
+++ b/.github/workflows/update-ed.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Checkout reffy
       uses: actions/checkout@master
       with:
-        repository: tidoust/reffy
+        repository: w3c/reffy
         ref: master
         fetch-depth: 1
         path: reffy

--- a/.github/workflows/update-tr.yml
+++ b/.github/workflows/update-tr.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Checkout reffy
       uses: actions/checkout@master
       with:
-        repository: tidoust/reffy
+        repository: w3c/reffy
         ref: master
         fetch-depth: 1
         path: reffy

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Individual files are named after the shortname of the specification, or after th
 
 The [ed/index.json](ed/index.json) and [tr/index.json](tr/index.json) files contain the index of specifications that have been crawled, and relative links to individual files that have been created.
 
-This repository uses [Reffy](https://github.com/tidoust/reffy), a Web spec exploration tool, to crawl the specifications and generate the data. In particular, the data it contains is the result of running Reffy. The repository does not contain any more data.
+This repository uses [Reffy](https://github.com/w3c/reffy), a Web spec exploration tool, to crawl the specifications and generate the data. In particular, the data it contains is the result of running Reffy. The repository does not contain any more data.
 
 Raw WebIDL extracts are used in [web-platform-tests](https://github.com/web-platform-tests/wpt), please see their [interfaces/README.md](https://github.com/web-platform-tests/wpt/blob/master/interfaces/README.md) for details.
 
@@ -34,7 +34,7 @@ On top of data extracted from the specifications, this repository also contains 
 
 Feel free to raise [issues in this repository](https://github.com/w3c/webref/issues) as needed. Note that most issues likely more directly apply to underlying tools:
 
-- Errors in the data are most likely caused by bugs or missing features in [Reffy](https://github.com/tidoust/reffy), which is the tool that crawls and parses specifications under the hoods. If you spot an error, please report it in [Reffy's issue tracker](https://github.com/tidoust/reffy/issues/new).
+- Errors in the data are most likely caused by bugs or missing features in [Reffy](https://github.com/w3c/reffy), which is the tool that crawls and parses specifications under the hoods. If you spot an error, please report it in [Reffy's issue tracker](https://github.com/w3c/reffy/issues/new).
 - If you believe that a spec is missing from the list, please check [browser-specs](https://github.com/w3c/browser-specs/#how-to-addupdatedelete-a-spec) and report it [there](https://github.com/w3c/browser-specs/issues/new).
 
 

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   </head>
   <body>
     <h1>Web Platform exploration with Reffy</h1>
-    <p><a href="https://github.com/tidoust/reffy">Reffy</a> is a <i>spec exploration tool</i>. It takes a list of specifications as input and:</p>
+    <p><a href="https://github.com/w3c/reffy">Reffy</a> is a <i>spec exploration tool</i>. It takes a list of specifications as input and:</p>
     <ol>
       <li>retrieves information about them (e.g. the URL of the latest Editor's Draft);</li>
       <li>fetches and parses latest Editor's Drafts to extract WebIDL content, links and references;</li>
@@ -40,7 +40,7 @@
 
     <section>
       <h2>About Reffy</h2>
-      <p>Reffy was initially created by <a href="https://github.com/tidoust/">François Daoust</a> and <a href="https://github.com/dontcallmedom/">Dominique Hazaël-Massieux</a> during the 2016 edition of the <a href="https://www.w3.org/blog/2016/07/exploring-web-platform-cross-dependencies/">W3C Geek Week</a>, and updated during the 2017 edition of that same W3C Geek Week. Code and instructions are available on <a href="https://github.com/tidoust/reffy" title="Reffy repository on GitHub">GitHub</a>. Feel free to report bugs  The code is available under an <a href="https://github.com/tidoust/reffy/blob/master/LICENSE">MIT license</a>.</p>
+      <p>Reffy was initially created by <a href="https://github.com/tidoust/">François Daoust</a> and <a href="https://github.com/dontcallmedom/">Dominique Hazaël-Massieux</a> during the 2016 edition of the <a href="https://www.w3.org/blog/2016/07/exploring-web-platform-cross-dependencies/">W3C Geek Week</a>, and updated during the 2017 edition of that same W3C Geek Week. Code and instructions are available on <a href="https://github.com/w3c/reffy" title="Reffy repository on GitHub">GitHub</a>. Feel free to report bugs  The code is available under an <a href="https://github.com/w3c/reffy/blob/master/LICENSE">MIT license</a>.</p>
     </section>
   </body>
 </html>


### PR DESCRIPTION
Reffy is being transfered to the w3c organization. This updates the references to Reffy to use `w3c/reffy` instead of `tidoust/reffy`.

See https://github.com/tidoust/reffy/issues/449

To be merged after the repo has moved.