### PR TITLE
Bump Node.js to v14.x in update actions

### DIFF
--- a/.github/workflows/update-ed.yml
+++ b/.github/workflows/update-ed.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@master
       with:
-        node-version: 10.x
+        node-version: 14.x
     - name: Install pandoc
       run: sudo apt-get install pandoc
     - name: Setup Reffy

--- a/.github/workflows/update-tr.yml
+++ b/.github/workflows/update-tr.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@master
       with:
-        node-version: 10.x
+        node-version: 14.x
     - name: Install pandoc
       run: sudo apt-get install pandoc
     - name: Setup Reffy


### PR DESCRIPTION
Force use of Node.js v14.x for crawl actions since Reffy will soon require it, see: https://github.com/w3c/reffy/pull/458