### PR TITLE
Make it possible to run workflows manually

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -3,6 +3,7 @@ name: Clean up abandoned files
 on:
   schedule:
     - cron: '30 0 * * 1'
+  workflow_dispatch:
 jobs:
   update:
     runs-on: ubuntu-18.04

--- a/.github/workflows/update-ed.yml
+++ b/.github/workflows/update-ed.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+  workflow_dispatch:
 name: Update ED report
 jobs:
   update:

--- a/.github/workflows/update-tr.yml
+++ b/.github/workflows/update-tr.yml
@@ -1,6 +1,7 @@
 on:
   schedule:
     - cron: '11 11 * * 1'
+  workflow_dispatch:
 name: Update TR report
 jobs:
   update:


### PR DESCRIPTION
Add a `workflow_dispatch` event to make it possible to run the workflows from the GitHub interface (and API if needed), see:
https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#workflow_dispatch