### PR TITLE
Adjust cleanup job to also look at IDL names folders

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -2,7 +2,7 @@ name: Clean up abandoned files
 
 on:
   schedule:
-    - cron: '30 0 * * 1'
+    - cron: '0 2 * * 1'
   workflow_dispatch:
 jobs:
   update:

--- a/.github/workflows/update-tr.yml
+++ b/.github/workflows/update-tr.yml
@@ -1,6 +1,6 @@
 on:
   schedule:
-    - cron: '11 11 * * 1'
+    - cron: '0 1 * * 1'
   workflow_dispatch:
 name: Update TR report
 jobs:

--- a/tools/clean-abandoned-files.js
+++ b/tools/clean-abandoned-files.js
@@ -4,6 +4,7 @@ const ed = require("../ed/index.json");
 const tr = require("../tr/index.json");
 
 const subdirs = ["dfns", "css", "headings", "idl", "idlparsed", "links", "refs"];
+const idlnamesSubdirs = ["idlnames", "idlnamesparsed"];
 
 
 const removeExtension = f => {
@@ -21,7 +22,45 @@ function checkDir(path, index) {
   }
 }
 
+function checkIdlNames(path, index) {
+  // Build the list of IDL names from idlparsed extracts
+  const idlFiles = new Set(index.results.map(spec => spec.idlparsed).filter(s => !!s));
+  let idlNames = new Set();
+  for (const idlFile of idlFiles) {
+    const idlparsed = require("../" + path + "/" + idlFile);
+    if (!idlparsed || !idlparsed.idlparsed) {
+      continue;
+    }
+    if (idlparsed.idlparsed.idlNames) {
+      for (const name of Object.keys(idlparsed.idlparsed.idlNames)) {
+        idlNames.add(name);
+      }
+    }
+    if (idlparsed.idlparsed.idlExtendedNames) {
+      for (const name of Object.keys(idlparsed.idlparsed.idlExtendedNames)) {
+        idlNames.add(name);
+      }
+    }
+  }
+
+  // Parse subfolders that contain files named after IDL names
+  for (const subdir of idlnamesSubdirs) {
+    if (!fs.existsSync(path + "/" + subdir)) {
+      continue;
+    }
+    const filenames = fs.readdirSync(path + "/" + subdir);
+    for (const filename of filenames) {
+      const name = filename.match(/(.+)\.[^\.]+$/)[1];
+      if (!idlNames.has(name)) {
+        fs.unlinkSync(path + "/" + subdir + "/" + filename);
+      }
+    }
+  }
+}
+
 for (let dir of subdirs) {
   checkDir("ed/" + dir, ed);
   checkDir("tr/" + dir, tr);
 }
+checkIdlNames("ed", ed);
+checkIdlNames("tr", tr);


### PR DESCRIPTION
The "idlnames" and "idlnameparsed" folders have recently been added, see:
https://github.com/w3c/reffy/pull/489#issuecomment-775859515

They contain files per IDL Name, which need to be dropped when the IDL names no longer appear in any of the crawled specs.

Also adjust jobs execution schedules to have the cleanup job run after the weekly tr crawl, see:
https://github.com/w3c/webref/pull/86#pullrequestreview-580112062