### PR TITLE
Switch Lerna to independent mode

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "1.0.0"
+  "version": "independent"
 }


### PR DESCRIPTION
https://github.com/lerna/lerna#independent-mode

The intention is for a @webref/css package to be versioned independently
of @webref/idl. In the meantime, this avoids two places for the same
version.