### PR TITLE
Split out setup to allow a subset of consistency tests to run

### DIFF
--- a/test/idl/all.js
+++ b/test/idl/all.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 
 const idl = require('@webref/idl');
 
@@ -7,7 +7,7 @@ describe('@webidl/idl module', () => {
     const files = await idl.listAll();
     assert(Object.keys(files).length > 0);
     for (const [shortname, file] of Object.entries(files)) {
-      assert.strictEqual(shortname, file.shortname);
+      assert.equal(shortname, file.shortname);
       assert(/^[a-z0-9-_]+$/i.exec(shortname),
           `invalid shortname: ${shortname}`);
     }

--- a/test/idl/consistency.js
+++ b/test/idl/consistency.js
@@ -186,6 +186,7 @@ describe('Web IDL consistency', () => {
     }
   });
 
+  // This test should remain the last one as it slightly modifies objects in dfns in place.
   it('merging in partials/mixins', () => {
     const merged = merge(dfns, partials, includes);
   });

--- a/test/idl/consistency.js
+++ b/test/idl/consistency.js
@@ -189,5 +189,22 @@ describe('Web IDL consistency', () => {
   // This test should remain the last one as it slightly modifies objects in dfns in place.
   it('merging in partials/mixins', () => {
     const merged = merge(dfns, partials, includes);
+    // To guard against new things being added to Web IDL which need special handling,
+    // such as dictionary mixins, check that the merged result has only known types.
+    // Also check that everything has a name and that no partials remain.
+    const knownTypes = new Set([
+      'callback interface',
+        'callback',
+        'dictionary',
+        'enum',
+        'interface',
+        'namespace',
+        'typedef'
+    ]);
+    for (const dfn of merged) {
+      assert(dfn.name, 'definition has a name');
+      assert(!dfn.partial, 'definition is not partial');
+      assert(knownTypes.has(dfn.type), `unknown definition type: ${dfn.type}`)
+    }
   });
 });

--- a/test/idl/validate.js
+++ b/test/idl/validate.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 const WebIDL2 = require('webidl2');
 
 const idl = require('@webref/idl');


### PR DESCRIPTION
The last testing (merging) still modifies the definitions, so these
tests still can't be run in any order. That would require parsing all of
the Web IDL for each test, which seems excessive.