### PR TITLE
Exclude svg-paths.idl from @webref/idl package

### DIFF
--- a/ed/idlpatches/SVG.idl.patch
+++ b/ed/idlpatches/SVG.idl.patch
@@ -1,19 +1,19 @@
-From 4e5f3980c2e042f7f2f5abeeba9a382b8d7e9fc0 Mon Sep 17 00:00:00 2001
+From 50c80eeaf5eaf5a22ec14ee5a97e1438e17ce172 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Philip=20J=C3=A4genstedt?= <philip@foolip.org>
 Date: Fri, 12 Feb 2021 12:09:11 +0100
 Subject: [PATCH] Fix SVG.idl
 
 HTMLHyperlinkElementUtils: https://github.com/w3c/svgwg/issues/312
 
-Duplicates: https://github.com/w3c/svgwg/issues/824
+SVGMarkerElement: https://github.com/w3c/svgwg/issues/824
 
-Constructor: https://github.com/w3c/svgwg/pull/825
+ShadowAnimation: https://github.com/w3c/svgwg/pull/825
 ---
- ed/idl/SVG.idl | 50 ++++++++++++++++----------------------------------
- 1 file changed, 16 insertions(+), 34 deletions(-)
+ ed/idl/SVG.idl | 46 ++++++++++++++++------------------------------
+ 1 file changed, 16 insertions(+), 30 deletions(-)
 
 diff --git a/ed/idl/SVG.idl b/ed/idl/SVG.idl
-index f8d24c9c6..2e7d438fa 100644
+index f8d24c9c6..0bf7d418a 100644
 --- a/ed/idl/SVG.idl
 +++ b/ed/idl/SVG.idl
 @@ -314,8 +314,9 @@ interface mixin SVGElementInstance {
@@ -27,18 +27,7 @@ index f8d24c9c6..2e7d438fa 100644
    [SameObject] readonly attribute Animation sourceAnimation;
  };
  
-@@ -417,10 +418,6 @@ interface SVGAnimatedPreserveAspectRatio {
-   [SameObject] readonly attribute SVGPreserveAspectRatio animVal;
- };
- 
--[Exposed=Window]
--interface SVGPathElement : SVGGeometryElement {
--};
--
- [Exposed=Window]
- interface SVGRectElement : SVGGeometryElement {
-   [SameObject] readonly attribute SVGAnimatedLength x;
-@@ -566,34 +563,6 @@ interface SVGForeignObjectElement : SVGGraphicsElement {
+@@ -566,34 +567,6 @@ interface SVGForeignObjectElement : SVGGraphicsElement {
    [SameObject] readonly attribute SVGAnimatedLength height;
  };
  
@@ -73,7 +62,7 @@ index f8d24c9c6..2e7d438fa 100644
  [Exposed=Window]
  interface SVGGradientElement : SVGElement {
  
-@@ -671,7 +640,20 @@ interface SVGAElement : SVGGraphicsElement {
+@@ -671,7 +644,20 @@ interface SVGAElement : SVGGraphicsElement {
  };
  
  SVGAElement includes SVGURIReference;
@@ -96,5 +85,5 @@ index f8d24c9c6..2e7d438fa 100644
  [Exposed=Window]
  interface SVGViewElement : SVGElement {};
 -- 
-2.30.0.365.g02bc693789-goog
+2.30.1.669.gdc6e27a789-goog
 

--- a/ed/idlpatches/svg-paths.idl.patch
+++ b/ed/idlpatches/svg-paths.idl.patch
@@ -1,41 +1,50 @@
-From 6249221af1d31f2ccf8333bdca89f992df4f95d4 Mon Sep 17 00:00:00 2001
+From 98c3d3d90d4d26042b4bb5a3e261d72d47cd6923 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Philip=20J=C3=A4genstedt?= <philip@foolip.org>
-Date: Fri, 3 Jul 2020 23:00:39 +0200
-Subject: [PATCH] Fix svg-paths.idl
+Date: Fri, 19 Feb 2021 09:42:26 +0100
+Subject: [PATCH] Remove svg-paths.idl
 
-https://github.com/w3c/svgwg/pull/802
-https://github.com/w3c/svgwg/pull/826
+https://github.com/w3c/svgwg/issues/818
 ---
- ed/idl/svg-paths.idl | 9 ++++-----
- 1 file changed, 4 insertions(+), 5 deletions(-)
+ ed/idl/svg-paths.idl | 30 ------------------------------
+ 1 file changed, 30 deletions(-)
+ delete mode 100644 ed/idl/svg-paths.idl
 
 diff --git a/ed/idl/svg-paths.idl b/ed/idl/svg-paths.idl
-index 84a067491..ef38bd1a9 100644
+deleted file mode 100644
+index 84a067491..000000000
 --- a/ed/idl/svg-paths.idl
-+++ b/ed/idl/svg-paths.idl
-@@ -3,18 +3,17 @@
- // (https://github.com/w3c/webref)
- // Source: SVG Paths (https://svgwg.org/specs/paths/)
- 
++++ /dev/null
+@@ -1,30 +0,0 @@
+-// GENERATED CONTENT - DO NOT EDIT
+-// Content was automatically extracted by Reffy into webref
+-// (https://github.com/w3c/webref)
+-// Source: SVG Paths (https://svgwg.org/specs/paths/)
+-
 -[NoInterfaceObject]
- interface SVGPathSegment {
+-interface SVGPathSegment {
 -  DOMString type;
 -  sequence<float> values;
-+  attribute DOMString type;
-+  attribute FrozenArray<float> values;
- };
- 
- dictionary SVGPathDataSettings {
-    boolean normalize = false;
+-};
+-
+-dictionary SVGPathDataSettings {
+-   boolean normalize = false;
 -}
-+};
- 
- interface mixin SVGPathData {
+-
+-interface mixin SVGPathData {
 -   sequence<SVGPathSegment> getPathData(optional SVGPathDataSettings settings);
-+   sequence<SVGPathSegment> getPathData(optional SVGPathDataSettings settings = {});
-    void setPathData(sequence<SVGPathSegment> pathData);
- };
- 
+-   void setPathData(sequence<SVGPathSegment> pathData);
+-};
+-
+-interface SVGPathElement : SVGGeometryElement {
+-
+-  readonly attribute SVGAnimatedNumber pathLength;
+-
+-  float getTotalLength();
+-  DOMPoint getPointAtLength(float distance);
+-  SVGPathSegment? getPathSegmentAtLength(float distance);
+-};
+-
+-SVGPathElement includes SVGPathData;
 -- 
-2.30.0.365.g02bc693789-goog
+2.30.1.669.gdc6e27a789-goog
 


### PR DESCRIPTION
The patch for SVG.idl is adjusted to include its definition of
SVGPathElement, which doesn't have any members.

See https://github.com/w3c/svgwg/issues/818