### PR TITLE
Add jobs to semi-automate publication of @webref/idl package

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -2,7 +2,7 @@ name: Clean up abandoned files
 
 on:
   schedule:
-    - cron: '0 2 * * 1'
+    - cron: '0 3 * * 3'
   workflow_dispatch:
 jobs:
   update:

--- a/.github/workflows/prepare-idl-release.yml
+++ b/.github/workflows/prepare-idl-release.yml
@@ -1,0 +1,89 @@
+# Create a PR that bumps the version of packages/idl/package.json when changes
+# are detected compared with the latest version of the package published on NPM.
+#
+# Typical weekly schedule:
+# - New browser-specs release on Monday,
+# - Integration of new version of browser-specs in Reffy on Tuesday
+# - Cleanup job on Wednesday
+# - (This job) New @webref/idl package release on Thursday
+
+name: Prepare new @webref/idl release PR if needed
+
+on:
+  schedule:
+    - cron: '0 4 * * 4'
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Setup node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: 14.x
+
+    # Checkout webref and prepare new release in a separate folder so that we
+    # may also install the current version of @webref/idl for comparison.
+    - name: Checkout webref
+      uses: actions/checkout@v2
+      with:
+        path: webref
+
+    - name: Prepare new release
+      run: |
+        npm ci
+        npm run prepare
+      working-directory: webref
+
+    - name: Test new release
+      run: npm test
+      working-directory: webref
+
+    - name: Install current @webref/idl package for comparison
+      run: |
+        mkdir idl
+        cd idl
+        npm install @webref/idl
+
+    - name: Compute diff between new release and current package
+      # For details on syntax to use to export a multiline string to an
+      # environment variable, see:
+      # https://github.com/actions/toolkit/blob/main/docs/commands.md#set-an-environment-variable
+      # The diff does not take the package.json file into account because
+      # "npm install" adds properties that start with "_" to that file which do
+      # not exist in the repo version of the file.
+      run: |
+        echo 'IDL_DIFF<<EOF' >> $GITHUB_ENV
+        diff idl/node_modules/@webref/idl webref/packages/idl --ignore-trailing-space --exclude=package.json >> $GITHUB_ENV
+        echo 'EOF' >> $GITHUB_ENV
+
+    - name: Bump version number in packages/idl/package.json
+      if: ${{ env.IDL_DIFF }}
+      run: echo "RELEASE_VERSION=$(npm version patch)" >> $GITHUB_ENV
+      working-directory: webref/packages/idl
+
+    - name: Create pull request
+      uses: peter-evans/create-pull-request@v3
+      if: ${{ env.IDL_DIFF }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        path: webref
+        title: Release version ${{ env.RELEASE_VERSION }} of @webref/idl
+        commit-message: "Release version ${{ env.RELEASE_VERSION }} of @webref/idl"
+        body: |
+          Some changes were detected in the IDL since last time the `@webref/idl` package was released. Please review the IDL changes below.
+
+          If the IDL changes look good, a new version of the `@webref/idl` package should be released. This pull request bumps the patch part of the version number in `packages/idl/package.json`.
+
+          Please make sure that the changes to be released do not warrant bumping the major or minor part of the version number.
+
+          If all looks good (and if all goes well) merging this pull request will trigger the release of the package to npm.
+
+          ```diff
+          {{ env.IDL_DIFF }}
+          ```
+        assignees: dontcallmedom, foolip, tidoust
+        branch: release-idl
+        branch-suffix: timestamp

--- a/.github/workflows/release-idl.yml
+++ b/.github/workflows/release-idl.yml
@@ -43,10 +43,14 @@ jobs:
         package: ./packages/idl/package.json
         access: public
 
-    - name: Create GitHub release
-      uses: softprops/action-gh-release@v1
+    - name: Create version tag
       if: steps.publish.outputs.type != 'none'
+      run: |
+        git tag -a "@webref/idl@${{ steps.publish.outputs.version }}" -m "Publish @webref/idl@${{ steps.publish.outputs.version }}"
+
+    - name: Push version tag
+      if: steps.publish.outputs.type != 'none'
+      uses: ad-m/github-push-action@master
       with:
-        name: '@webref/idl@${{ steps.publish.outputs.version }}'
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        tags: true

--- a/.github/workflows/release-idl.yml
+++ b/.github/workflows/release-idl.yml
@@ -47,6 +47,6 @@ jobs:
       uses: softprops/action-gh-release@v1
       if: steps.publish.outputs.type != 'none'
       with:
-        name: @webref/idl@${{ steps.publish.outputs.version }}
+        name: '@webref/idl@${{ steps.publish.outputs.version }}'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-idl.yml
+++ b/.github/workflows/release-idl.yml
@@ -1,0 +1,52 @@
+# Runs whenever a push to the default branch updates the package.json file
+# of the @webref/idl package. The job publishes a new @webref/idl package to
+# npm and creates a new @webref/idl release on GitHub.
+#
+# The job will not do anything if the version number in package.json does not
+# differ from the one published on npm.
+
+name: Create and publish new @webref/idl release
+
+on:
+  push:
+    paths:
+      - 'packages/idl/package.json'  
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Setup node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: 14.x
+
+    - name: Checkout webref
+      uses: actions/checkout@v2
+
+    - name: Prepare new release
+      run: |
+        npm ci
+        npm run prepare
+
+    - name: Test new release
+      run: npm test
+
+    - name: Publish npm package
+      id: publish
+      uses: JS-DevTools/npm-publish@v1
+      with:
+        token: ${{ secrets.NPM_TOKEN }}
+        package: ./packages/idl/package.json
+        access: public
+
+    - name: Create GitHub release
+      uses: softprops/action-gh-release@v1
+      if: steps.publish.outputs.type != 'none'
+      with:
+        name: @webref/idl@${{ steps.publish.outputs.version }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This roughly implements the logic discussed in https://github.com/w3c/webref/issues/123#issuecomment-796650510:

1. The `prepare-idl-release` job runs on Thursday morning. It compares the latest contents of the repo with the published `@webref/idl` package on NPM, and creates a PR that bumps the version of the package in `packages/idl/package.json`, and exposes the diff of the IDL.

2. The `release-idl` job runs whenever an update to `packages/idl/package.json` gets pushed to the default branch. It publishes a new @webref/idl package to npm and creates a new @webref/idl release on GitHub. The job is a no op if the version number in package.json does not differ from the one published on npm.

If all goes well, merging the PR created by the first job will trigger the second job.

The update also moves the cleanup job to Wednesday morning instead of Monday.

If a patch no longer applies when the first job runs, it will fail. It won't create an issue in such cases, but repo admins will receive a "job failed" notification.

To be entirely clear, I have no idea whether these jobs are going to work as expected :) That said, at worst, they should simply do nothing and we should be able to iterate progressively to get them to do something useful.

If things work, the logic can easily be duplicated for the `@webref/css` package.