### PR TITLE
Stop running update-ed on pushes against default branch

### DIFF
--- a/.github/workflows/update-ed.yml
+++ b/.github/workflows/update-ed.yml
@@ -1,9 +1,6 @@
 on:
   schedule:
     - cron: '30 */6 * * *'
-  push:
-    branches:
-    - master
   workflow_dispatch:
 name: Update ED report
 jobs:


### PR DESCRIPTION
The `update-ed` job ran on pushes against the default branch but that does not make a lot of sense in practice. It also means that the job will run whenever we bump the version of a package in preparation for a release, and the job may thus clash with the release job.

The `update-ed` job can be triggered manually whenever needed.