### PR TITLE
Add committer name to tag / Adjust titles

### DIFF
--- a/.github/workflows/prepare-idl-release.yml
+++ b/.github/workflows/prepare-idl-release.yml
@@ -7,7 +7,7 @@
 # - Cleanup job on Wednesday
 # - (This job) New @webref/idl package release on Thursday
 
-name: Prepare new @webref/idl release PR if needed
+name: "@webref/idl: Prepare release PR if needed"
 
 on:
   schedule:
@@ -70,8 +70,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         path: webref
-        title: Release version ${{ env.RELEASE_VERSION }} of @webref/idl
-        commit-message: "Release version ${{ env.RELEASE_VERSION }} of @webref/idl"
+        title: "Release @webref/idl@${{ env.RELEASE_VERSION }}"
+        commit-message: "Release @webref/idl@${{ env.RELEASE_VERSION }}"
         body: |
           Some changes were detected in the IDL since last time the `@webref/idl` package was released. Please review the IDL changes below.
 

--- a/.github/workflows/release-idl.yml
+++ b/.github/workflows/release-idl.yml
@@ -5,7 +5,7 @@
 # The job will not do anything if the version number in package.json does not
 # differ from the one published on npm.
 
-name: Create and publish new @webref/idl release
+name: "@webref/idl: Publish npm package"
 
 on:
   push:
@@ -46,6 +46,8 @@ jobs:
     - name: Create version tag
       if: steps.publish.outputs.type != 'none'
       run: |
+        git config user.name "webref-release-bot"
+        git config user.email "<>"
         git tag -a "@webref/idl@${{ steps.publish.outputs.version }}" -m "Publish @webref/idl@${{ steps.publish.outputs.version }}"
 
     - name: Push version tag


### PR DESCRIPTION
This adds the missing committer name to create a Git tag, and adjusts the titles of the jobs (to find them more easily in the admin UI), and of the created PR (to simplify the title).