### PR TITLE
Manually add missing types to uievents.idl

### DIFF
--- a/ed/idlpatches/uievents.idl.patch
+++ b/ed/idlpatches/uievents.idl.patch
@@ -1,15 +1,16 @@
-From a22ea16d7bca3b8db9945cd967714ea166c2357d Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?Philip=20J=C3=A4genstedt?= <philip@foolip.org>
-Date: Wed, 17 Feb 2021 14:13:10 +0100
+From a7226b687cb8f5b654392aa191aace5bce1d4912 Mon Sep 17 00:00:00 2001
+From: Kagami Sascha Rosylight <saschanaz@outlook.com>
+Date: Fri, 19 Mar 2021 03:20:54 +0100
 Subject: [PATCH] Fix uievents.idl
 
-https://github.com/w3c/uievents/pull/292
+https://github.com/w3c/uievents/pull/287
+https://github.com/w3c/uievents/pull/296
 ---
- ed/idl/uievents.idl | 14 +++++++-------
- 1 file changed, 7 insertions(+), 7 deletions(-)
+ ed/idl/uievents.idl | 66 ++++++++++++++++++++++++++++++++++++++++-----
+ 1 file changed, 59 insertions(+), 7 deletions(-)
 
 diff --git a/ed/idl/uievents.idl b/ed/idl/uievents.idl
-index d5506ef77..a0936da4f 100644
+index d5506ef77..716998278 100644
 --- a/ed/idl/uievents.idl
 +++ b/ed/idl/uievents.idl
 @@ -5,7 +5,7 @@
@@ -75,6 +76,74 @@ index d5506ef77..a0936da4f 100644
    readonly attribute DOMString data;
  };
  
+@@ -152,11 +152,49 @@ dictionary CompositionEventInit : UIEventInit {
+   DOMString data = "";
+ };
+ 
++partial interface UIEvent {
++  // Deprecated in this specification
++  undefined initUIEvent();
++};
++
++partial interface MouseEvent {
++  // Deprecated in this specification
++  undefined initMouseEvent();
++};
++
++partial interface WheelEvent {
++  // Originally introduced (and deprecated) in this specification
++  undefined initWheelEvent();
++};
++
++partial interface KeyboardEvent {
++  // Originally introduced (and deprecated) in this specification
++  undefined initKeyboardEvent(DOMString typeArg,
++                              optional boolean bubblesArg = false,
++                              optional boolean cancelableArg = false,
++                              optional Window? viewArg = null,
++                              optional DOMString keyArg = "",
++                              optional unsigned long locationArg = 0,
++                              optional boolean ctrlKey = false,
++                              optional boolean altKey = false,
++                              optional boolean shiftKey = false,
++                              optional boolean metaKey = false);
++};
++
++partial interface CompositionEvent {
++  // Originally introduced (and deprecated) in this specification
++  undefined initCompositionEvent();
++};
++
+ partial interface UIEvent {
+   // The following support legacy user agents
+   readonly attribute unsigned long which;
+ };
+ 
++partial dictionary UIEventInit {
++  unsigned long which = 0;
++};
++
+ partial interface KeyboardEvent {
+   // The following support legacy user agents
+   readonly attribute unsigned long charCode;
+@@ -168,3 +206,17 @@ partial dictionary KeyboardEventInit {
+   unsigned long charCode = 0;
+   unsigned long keyCode = 0;
+ };
++
++interface MutationEvent : Event {
++  // attrChangeType
++  const unsigned short MODIFICATION = 1;
++  const unsigned short ADDITION = 2;
++  const unsigned short REMOVAL = 3;
++  readonly attribute Node? relatedNode;
++  readonly attribute DOMString prevValue;
++  readonly attribute DOMString newValue;
++  readonly attribute DOMString attrName;
++  readonly attribute unsigned short attrChange;
++
++  undefined initMutationEvent();
++};
 -- 
-2.30.0.365.g02bc693789-goog
+2.30.2.windows.1
 


### PR DESCRIPTION
This adds several missing legacy types.