### PR TITLE
Rebase the uievents.idl patch (parts of it applied)

### DIFF
--- a/ed/idlpatches/uievents.idl.patch
+++ b/ed/idlpatches/uievents.idl.patch
@@ -1,16 +1,15 @@
-From a7226b687cb8f5b654392aa191aace5bce1d4912 Mon Sep 17 00:00:00 2001
+From 2e9493bbe60c0558d5d9a5d91a17992a889c6906 Mon Sep 17 00:00:00 2001
 From: Kagami Sascha Rosylight <saschanaz@outlook.com>
 Date: Fri, 19 Mar 2021 03:20:54 +0100
 Subject: [PATCH] Fix uievents.idl
 
-https://github.com/w3c/uievents/pull/287
-https://github.com/w3c/uievents/pull/296
+https://github.com/w3c/uievents/pull/297
 ---
- ed/idl/uievents.idl | 66 ++++++++++++++++++++++++++++++++++++++++-----
- 1 file changed, 59 insertions(+), 7 deletions(-)
+ ed/idl/uievents.idl | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
 
 diff --git a/ed/idl/uievents.idl b/ed/idl/uievents.idl
-index d5506ef77..716998278 100644
+index 711b9620b..8eaab30ea 100644
 --- a/ed/idl/uievents.idl
 +++ b/ed/idl/uievents.idl
 @@ -5,7 +5,7 @@
@@ -76,74 +75,6 @@ index d5506ef77..716998278 100644
    readonly attribute DOMString data;
  };
  
-@@ -152,11 +152,49 @@ dictionary CompositionEventInit : UIEventInit {
-   DOMString data = "";
- };
- 
-+partial interface UIEvent {
-+  // Deprecated in this specification
-+  undefined initUIEvent();
-+};
-+
-+partial interface MouseEvent {
-+  // Deprecated in this specification
-+  undefined initMouseEvent();
-+};
-+
-+partial interface WheelEvent {
-+  // Originally introduced (and deprecated) in this specification
-+  undefined initWheelEvent();
-+};
-+
-+partial interface KeyboardEvent {
-+  // Originally introduced (and deprecated) in this specification
-+  undefined initKeyboardEvent(DOMString typeArg,
-+                              optional boolean bubblesArg = false,
-+                              optional boolean cancelableArg = false,
-+                              optional Window? viewArg = null,
-+                              optional DOMString keyArg = "",
-+                              optional unsigned long locationArg = 0,
-+                              optional boolean ctrlKey = false,
-+                              optional boolean altKey = false,
-+                              optional boolean shiftKey = false,
-+                              optional boolean metaKey = false);
-+};
-+
-+partial interface CompositionEvent {
-+  // Originally introduced (and deprecated) in this specification
-+  undefined initCompositionEvent();
-+};
-+
- partial interface UIEvent {
-   // The following support legacy user agents
-   readonly attribute unsigned long which;
- };
- 
-+partial dictionary UIEventInit {
-+  unsigned long which = 0;
-+};
-+
- partial interface KeyboardEvent {
-   // The following support legacy user agents
-   readonly attribute unsigned long charCode;
-@@ -168,3 +206,17 @@ partial dictionary KeyboardEventInit {
-   unsigned long charCode = 0;
-   unsigned long keyCode = 0;
- };
-+
-+interface MutationEvent : Event {
-+  // attrChangeType
-+  const unsigned short MODIFICATION = 1;
-+  const unsigned short ADDITION = 2;
-+  const unsigned short REMOVAL = 3;
-+  readonly attribute Node? relatedNode;
-+  readonly attribute DOMString prevValue;
-+  readonly attribute DOMString newValue;
-+  readonly attribute DOMString attrName;
-+  readonly attribute unsigned short attrChange;
-+
-+  undefined initMutationEvent();
-+};
 -- 
-2.30.2.windows.1
+2.31.0.rc2.261.g7f71774620-goog
 


### PR DESCRIPTION
https://github.com/w3c/uievents/pull/297 should fix what remains by
fixing the spec build/deploy.