### PR TITLE
Add temporary patch for WebTransport

### DIFF
--- a/ed/idlpatches/webtransport.idl.patch
+++ b/ed/idlpatches/webtransport.idl.patch
@@ -1,0 +1,53 @@
+From 4e7d7acc3a55b774b4a1836e6374c43642cb6e9a Mon Sep 17 00:00:00 2001
+From: Francois Daoust <fd@tidoust.net>
+Date: Thu, 1 Apr 2021 10:38:13 +0200
+Subject: [PATCH] [PATCH] Rollback to previous version to fix mixin inheritance
+
+https://github.com/w3c/webtransport/pull/241
+https://github.com/w3c/webtransport/issues/239
+---
+ ed/idl/webtransport.idl | 13 ++++++++-----
+ 1 file changed, 8 insertions(+), 5 deletions(-)
+
+diff --git a/ed/idl/webtransport.idl b/ed/idl/webtransport.idl
+index 94ab158cd..b86bab8ed 100644
+--- a/ed/idl/webtransport.idl
++++ b/ed/idl/webtransport.idl
+@@ -75,26 +75,29 @@ dictionary WebTransportStats {
+ };
+ 
+ [ Exposed=(Window,Worker) ]
+-interface mixin OutgoingStream : WritableStream /* of Uint8Array */ {
++interface mixin OutgoingStream {
++  readonly attribute WritableStream writable;
+   readonly attribute Promise<StreamAbortInfo> writingAborted;
+   undefined abortWriting(optional StreamAbortInfo abortInfo = {});
+ };
+ 
+ dictionary StreamAbortInfo {
+-  [EnforceRange] octet errorCode = 0;
++  unsigned long long errorCode = 0;
+ };
+ 
+ [ Exposed=(Window,Worker) ]
+-interface mixin IncomingStream : ReadableStream /* of Uint8Array */ {
++interface mixin IncomingStream {
++  /* a ReadableStream of Uint8Array */
++  readonly attribute ReadableStream readable;
+   readonly attribute Promise<StreamAbortInfo> readingAborted;
+   undefined abortReading(optional StreamAbortInfo abortInfo = {});
+ };
+ 
+ [ Exposed=(Window,Worker) ]
+ interface BidirectionalStream {
+-  readonly attribute ReceiveStream readable;
+-  readonly attribute SendStream writable;
+ };
++BidirectionalStream includes OutgoingStream;
++BidirectionalStream includes IncomingStream;
+ 
+ [ Exposed=(Window,Worker) ]
+ interface SendStream {
+-- 
+2.31.0.windows.1
+


### PR DESCRIPTION
The patch rolls back the IDL to what it was before the introduction of mixins with inheritance.