### PR TITLE
Release @webref/idl@v1.1.0

### DIFF
--- a/packages/idl/package.json
+++ b/packages/idl/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@webref/idl",
   "description": "Web IDL definitions of the web platform",
-  "version": "1.0.14",
+  "version": "1.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/w3c/webref.git"


### PR DESCRIPTION
The new guarantees around validity and consistency warrant a minor
release:
https://github.com/w3c/webref/pull/167
https://github.com/w3c/webref/pull/168
https://github.com/w3c/webref/pull/171
https://github.com/w3c/webref/pull/172