### PR TITLE
Release @webref/idl@v2.0.0

### DIFF
--- a/packages/idl/package.json
+++ b/packages/idl/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@webref/idl",
   "description": "Web IDL definitions of the web platform",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/w3c/webref.git"


### PR DESCRIPTION
This major release is because the webidl2 peerDependency was bumped:
https://github.com/w3c/webref/pull/181

See https://github.com/semver/semver/issues/502 for precedent.