### PR TITLE
Print a relative path when applying CSS/IDL patches

### DIFF
--- a/packages/prepare.js
+++ b/packages/prepare.js
@@ -48,7 +48,7 @@ async function main() {
     for (const file of patchFiles) {
       if (file.endsWith('.patch')) {
         const patch = path.join(patchDir, file);
-        console.log(`Applying ${patch}`);
+        console.log(`Applying ${path.relative(rootDir, patch)}`);
         await execFile('git', ['apply', `--directory=packages/${name}`, '-p3', patch], {
           cwd: rootDir
         });


### PR DESCRIPTION
This makes it easier to copy-paste the path in the output, and it's also
less verbose + consistent locally and in CI.