### PR TITLE
Update update-workflows with a late webref checkout

### DIFF
--- a/.github/workflows/update-ed.yml
+++ b/.github/workflows/update-ed.yml
@@ -7,10 +7,6 @@ jobs:
   update:
     runs-on: ubuntu-18.04
     steps:
-    - name: Checkout webref
-      uses: actions/checkout@master
-      with:
-        path: webref
     - name: Checkout reffy
       uses: actions/checkout@master
       with:
@@ -31,6 +27,10 @@ jobs:
     - name: Run Reffy's crawler
       run: npm run ed
       working-directory: reffy
+    - name: Checkout webref
+      uses: actions/checkout@master
+      with:
+        path: webref
     - name: Copy reports
       run: rsync -av --exclude=README.md reffy/reports/ webref/
     - name: Push updates to git

--- a/.github/workflows/update-tr.yml
+++ b/.github/workflows/update-tr.yml
@@ -7,10 +7,6 @@ jobs:
   update:
     runs-on: ubuntu-18.04
     steps:
-    - name: Checkout webref
-      uses: actions/checkout@master
-      with:
-        path: webref
     - name: Checkout reffy
       uses: actions/checkout@master
       with:
@@ -31,6 +27,10 @@ jobs:
     - name: Run Reffy's crawler
       run: npm run tr
       working-directory: reffy
+    - name: Checkout webref
+      uses: actions/checkout@master
+      with:
+        path: webref
     - name: Copy reports
       run: rsync -av --exclude=README.md reffy/reports/ webref/
     - name: Push updates to git


### PR DESCRIPTION
The crawl is what takes longest, and if a PR gets merged during the crawl, the git push at the end won't work anymore. By leaving the checkout after the crawl, the window of risks for this to happen is a lot smaller