### PR TITLE
Validate all IDL together to catch additional issues

### DIFF
--- a/ed/idlpatches/SVG-arg-default.idl.patch
+++ b/ed/idlpatches/SVG-arg-default.idl.patch
@@ -1,0 +1,44 @@
+From 5e39e69ce9e6db4dfb7b0fecee9904868d90c697 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Philip=20J=C3=A4genstedt?= <philip@foolip.org>
+Date: Thu, 22 Apr 2021 12:05:55 +0200
+Subject: [PATCH] Fix SVG.idl
+
+https://github.com/w3c/svgwg/pull/844
+---
+ ed/idl/SVG.idl | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/ed/idl/SVG.idl b/ed/idl/SVG.idl
+index 3b530cb69..9ce619d1e 100644
+--- a/ed/idl/SVG.idl
++++ b/ed/idl/SVG.idl
+@@ -253,7 +253,7 @@ interface SVGSVGElement : SVGGraphicsElement {
+   DOMMatrix createSVGMatrix();
+   DOMRect createSVGRect();
+   SVGTransform createSVGTransform();
+-  SVGTransform createSVGTransformFromMatrix(optional DOMMatrix2DInit matrix);
++  SVGTransform createSVGTransformFromMatrix(optional DOMMatrix2DInit matrix = {});
+ 
+   Element getElementById(DOMString elementId);
+ 
+@@ -354,7 +354,7 @@ interface SVGTransform {
+   [SameObject] readonly attribute DOMMatrix matrix;
+   readonly attribute float angle;
+ 
+-  undefined setMatrix(optional DOMMatrix2DInit matrix);
++  undefined setMatrix(optional DOMMatrix2DInit matrix = {});
+   undefined setTranslate(float tx, float ty);
+   undefined setScale(float sx, float sy);
+   undefined setRotate(float angle, float cx, float cy);
+@@ -378,7 +378,7 @@ interface SVGTransformList {
+   setter undefined (unsigned long index, SVGTransform newItem);
+ 
+   // Additional methods not common to other list interfaces.
+-  SVGTransform createSVGTransformFromMatrix(optional DOMMatrix2DInit matrix);
++  SVGTransform createSVGTransformFromMatrix(optional DOMMatrix2DInit matrix = {});
+   SVGTransform? consolidate();
+ };
+ 
+-- 
+2.31.1.368.gbe11c130af-goog
+

--- a/test/idl/validate.js
+++ b/test/idl/validate.js
@@ -3,22 +3,32 @@ const WebIDL2 = require('webidl2');
 
 const idl = require('@webref/idl');
 
+function validate(ast) {
+  const validations = WebIDL2.validate(ast).filter(v => {
+    // Ignore the [LegacyNoInterfaceObject] rule.
+    return v.ruleName !== 'no-nointerfaceobject';
+  });
+  if (!validations.length) {
+    return;
+  }
+  const message = validations.map(v => {
+    return `${v.message} [${v.ruleName}]`;
+  }).join('\n\n');
+  assert.fail(message);
+}
+
 idl.parseAll().then((all) => {
   describe('WebIDL2.validate', () => {
     for (const [spec, ast] of Object.entries(all)) {
       it(spec, () => {
-        const validations = WebIDL2.validate(ast).filter(v => {
-          // Ignore the [LegacyNoInterfaceObject] rule.
-          return v.ruleName !== 'no-nointerfaceobject';
-        });
-        if (!validations.length) {
-          return;
-        }
-        const message = validations.map(v => {
-          return `${v.message} [${v.ruleName}]`;
-        }).join('\n\n');
-        assert.fail(message);
+        validate(ast);
       });
     }
+
+    // Also validate all IDL together. Some validation rules have insufficient
+    // type information when looking at each spec in isolation.
+    it('all IDL together', () => {
+      validate(Object.values(all).flat());
+    });
   });
 }).then(run);


### PR DESCRIPTION
Because DOMMatrix2DInit is defined in geometry.idl, when validating just
SVG.idl in isolation it's not known that DOMMatrix2DInit has no required
members, so the error about missing default {} is missed.