### PR TITLE
Adjust patch for Web Animations 2

### DIFF
--- a/ed/idlpatches/web-animations-2.idl.patch
+++ b/ed/idlpatches/web-animations-2.idl.patch
@@ -1,38 +1,20 @@
-From 77438b7fa65e8f54ee68c9d224e55a1552bbb3e9 Mon Sep 17 00:00:00 2001
+From 02c8a7920291c53ab07942930c4234c240aff8f1 Mon Sep 17 00:00:00 2001
 From: Francois Daoust <fd@tidoust.net>
-Date: Thu, 6 May 2021 10:48:57 +0200
-Subject: [PATCH] [PATCH] void to undefined, default value for optional param
+Date: Thu, 6 May 2021 15:32:18 +0200
+Subject: [PATCH] Drop duplicate `fillMode` enum definition
 
-https://github.com/w3c/csswg-drafts/pull/6271
-
-Patch also drops duplicate `fillMode` enum definition. The spec is a delta spec
-and re-defines that enum because it updates the meaning of one of its values.
-We'll likely need to keep the patch around for this as long as the spec remains
-a delta spec.
+The spec is a delta spec and re-defines that enum because it updates the meaning
+of one of its values. Patch will likely need to be kept around for as long as
+the spec remains a delta spec.
 ---
- ed/idl/web-animations-2.idl | 20 +++++++++-----------
- 1 file changed, 9 insertions(+), 11 deletions(-)
+ ed/idl/web-animations-2.idl | 2 --
+ 1 file changed, 2 deletions(-)
 
 diff --git a/ed/idl/web-animations-2.idl b/ed/idl/web-animations-2.idl
-index e3e148ff0..bf4f9aa18 100644
+index 628282743..bf4f9aa18 100644
 --- a/ed/idl/web-animations-2.idl
 +++ b/ed/idl/web-animations-2.idl
-@@ -15,10 +15,10 @@ partial interface AnimationEffect {
-     readonly attribute AnimationEffect? previousSibling;
-     readonly attribute AnimationEffect? nextSibling;
- 
--    void before (AnimationEffect... effects);
--    void after (AnimationEffect... effects);
--    void replace (AnimationEffect... effects);
--    void remove ();
-+    undefined before (AnimationEffect... effects);
-+    undefined after (AnimationEffect... effects);
-+    undefined replace (AnimationEffect... effects);
-+    undefined remove ();
- };
- 
- partial dictionary EffectTiming {
-@@ -33,20 +33,18 @@ partial dictionary ComputedEffectTiming {
+@@ -33,8 +33,6 @@ partial dictionary ComputedEffectTiming {
      double startTime;
  };
  
@@ -41,38 +23,6 @@ index e3e148ff0..bf4f9aa18 100644
  [Exposed=Window]
  interface GroupEffect {
    constructor(sequence<AnimationEffect>? children,
--              optional (unrestricted double or EffectTiming) timing);
-+              optional (unrestricted double or EffectTiming) timing = {});
- 
-   readonly attribute AnimationNodeList  children;
-   readonly attribute AnimationEffect?   firstChild;
-   readonly attribute AnimationEffect?   lastChild;
-   GroupEffect clone ();
- 
--  void prepend (AnimationEffect... effects);
--  void append (AnimationEffect... effects);
-+  undefined prepend (AnimationEffect... effects);
-+  undefined append (AnimationEffect... effects);
- };
- 
- [Exposed=Window]
-@@ -58,7 +56,7 @@ interface AnimationNodeList {
- [Exposed=Window]
- interface SequenceEffect : GroupEffect {
-   constructor(sequence<AnimationEffect>? children,
--              optional (unrestricted double or EffectTiming) timing);
-+              optional (unrestricted double or EffectTiming) timing = {});
- 
-   SequenceEffect clone ();
- };
-@@ -73,6 +71,6 @@ partial dictionary KeyframeEffectOptions {
- 
- enum IterationCompositeOperation { "replace", "accumulate" };
- 
--callback EffectCallback = void (double? progress,
-+callback EffectCallback = undefined (double? progress,
-                                 (Element or CSSPseudoElement) currentTarget,
-                                 Animation animation);
 -- 
 2.31.0.windows.1
 


### PR DESCRIPTION
PR was merged. What remains is the duplicated fillMode enum declaration, triggered by the fact that the spec is a delta spec.