### PR TITLE
Add IDL patches for CSS Typed OM and Payment Request

### DIFF
--- a/ed/idlpatches/css-typed-om.idl.patch
+++ b/ed/idlpatches/css-typed-om.idl.patch
@@ -3,11 +3,7 @@ From: Francois Daoust <fd@tidoust.net>
 Date: Mon, 17 May 2021 14:21:51 +0200
 Subject: [PATCH] Restore previous definition for CSSColor
 
-New definition references not yet defined `CSSPercentishArray` structure:
-https://github.com/w3c/css-houdini-drafts/commit/8d1990684d86ad7cf1e58ba414114c8811c04ee3
-
-Property should eventually get fixed by:
-https://github.com/w3c/css-houdini-drafts/issues/1037
+https://github.com/w3c/css-houdini-drafts/issues/1041
 ---
  ed/idl/css-typed-om.idl | 7 +++----
  1 file changed, 3 insertions(+), 4 deletions(-)

--- a/ed/idlpatches/css-typed-om.idl.patch
+++ b/ed/idlpatches/css-typed-om.idl.patch
@@ -1,0 +1,35 @@
+From 19fbd9a43ddae066c864e4dbcd3493cd96e7aadb Mon Sep 17 00:00:00 2001
+From: Francois Daoust <fd@tidoust.net>
+Date: Mon, 17 May 2021 14:21:51 +0200
+Subject: [PATCH] Restore previous definition for CSSColor
+
+New definition references not yet defined `CSSPercentishArray` structure:
+https://github.com/w3c/css-houdini-drafts/commit/8d1990684d86ad7cf1e58ba414114c8811c04ee3
+
+Property should eventually get fixed by:
+https://github.com/w3c/css-houdini-drafts/issues/1037
+---
+ ed/idl/css-typed-om.idl | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/ed/idl/css-typed-om.idl b/ed/idl/css-typed-om.idl
+index 9be9a1a76..262d2884e 100644
+--- a/ed/idl/css-typed-om.idl
++++ b/ed/idl/css-typed-om.idl
+@@ -371,10 +371,9 @@ interface CSSLab : CSSColorValue {
+ 
+ [Exposed=(Window, Worker, PaintWorklet, LayoutWorklet)]
+ interface CSSColor : CSSColorValue {
+-    constructor(CSSKeywordish colorSpace, sequence<CSSNumberish> channels, optional CSSNumberish alpha = 1);
+-    attribute CSSKeywordish colorSpace;
+-    attribute CSSPercentishArray channels;
+-    attribute CSSNumberish alpha;
++    constructor(sequence<(DOMString or CSSNumberish)> variant);
++    /* CSSColor(["foo", 0, 1, .5], ["bar", "yellow"], 1, fallbackColor) */
++    /* or just make the alpha and fallback successive optional args? */
+ };
+ 
+ [Exposed=(Window, Worker, PaintWorklet, LayoutWorklet)]
+-- 
+2.31.1.windows.1
+

--- a/ed/idlpatches/payment-request.idl.patch
+++ b/ed/idlpatches/payment-request.idl.patch
@@ -1,0 +1,53 @@
+From d00f84ad858cc457d0e894218931ef6b28cc6d4d Mon Sep 17 00:00:00 2001
+From: Francois Daoust <fd@tidoust.net>
+Date: Mon, 17 May 2021 13:47:50 +0200
+Subject: [PATCH] Restore PaymentAddress and AddressErrors interface
+
+Still used in Contact API:
+https://github.com/WICG/contact-api/pull/39
+
+Still referenced by Basic Card Payment Method:
+https://github.com/w3c/payment-method-basic-card/issues/89
+---
+ ed/idl/payment-request.idl | 28 ++++++++++++++++++++++++++++
+ 1 file changed, 28 insertions(+)
+
+diff --git a/ed/idl/payment-request.idl b/ed/idl/payment-request.idl
+index b66bb1592..cd16e2aab 100644
+--- a/ed/idl/payment-request.idl
++++ b/ed/idl/payment-request.idl
+@@ -103,3 +103,31 @@ interface PaymentRequestUpdateEvent : Event {
+ };
+ 
+ dictionary PaymentRequestUpdateEventInit : EventInit {};
++
++[SecureContext, Exposed=(Window)]
++interface PaymentAddress {
++  [Default] object toJSON();
++  readonly attribute DOMString city;
++  readonly attribute DOMString country;
++  readonly attribute DOMString dependentLocality;
++  readonly attribute DOMString organization;
++  readonly attribute DOMString phone;
++  readonly attribute DOMString postalCode;
++  readonly attribute DOMString recipient;
++  readonly attribute DOMString region;
++  readonly attribute DOMString sortingCode;
++  readonly attribute FrozenArray<DOMString> addressLine;
++};
++
++dictionary AddressErrors {
++  DOMString addressLine;
++  DOMString city;
++  DOMString country;
++  DOMString dependentLocality;
++  DOMString organization;
++  DOMString phone;
++  DOMString postalCode;
++  DOMString recipient;
++  DOMString region;
++  DOMString sortingCode;
++};
+-- 
+2.31.1.windows.1
+


### PR DESCRIPTION
- CSS Typed OM: restore previous definition of CSSColor as new definition references not yet defined CSSPercentishArray type
- Payment Request: restore PaymentAddress and AddressErrors interfaces, dropped from the spec but still referenced by "Method Payment: Basic Card" and by the Contacts API