### PR TITLE
Fix patch for css-page

### DIFF
--- a/ed/csspatches/css-page.json.patch
+++ b/ed/csspatches/css-page.json.patch
@@ -3,6 +3,8 @@ From: Francois Daoust <fd@tidoust.net>
 Date: Thu, 4 Mar 2021 16:09:10 +0100
 Subject: [PATCH] Drop invalid comment in value definition
 
+Related bug in Reffy:
+https://github.com/w3c/reffy/issues/534
 ---
  ed/css/css-page.json | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
@@ -19,7 +21,7 @@ index bfcaef74d..759e0cae0 100644
 +      "value": "':' [ left | right | first | blank ]"
      },
      "<page-size>": {
-       "prose": "A page size can be specified using one of the following media names. This is the equivalent of specifying size using length values. The definition of the media names comes from Media Standardized Names [PWGMSN]. A5 Equivalent to the size of ISO A5 media: 148mm wide and 210 mm high. A4 Equivalent to the size of ISO A4 media: 210 mm wide and 297 mm high. A3 Equivalent to the size of ISO A3 media: 297mm wide and 420mm high. B5 Equivalent to the size of ISO B5 media: 176mm wide by 250mm high. B4 Equivalent to the size of ISO B4 media: 250mm wide by 353mm high. JIS-B5 Equivalent to the size of JIS B5 media: 182mm wide by 257mm high. JIS-B4 Equivalent to the size of JIS B4 media: 257mm wide by 364mm high. letter Equivalent to the size of North American letter media: 8.5 inches wide and 11 inches high legal Equivalent to the size of North American legal: 8.5 inches wide by 14 inches high. ledger Equivalent to the size of North American ledger: 11 inches wide by 17 inches high."
+       "prose": "A page size can be specified using one of the following media names. This is the equivalent of specifying size using length values. The definition of the media names comes from Media Standardized Names [PWGMSN]."
 -- 
 2.30.1.windows.1
 


### PR DESCRIPTION
Patch no longer applied because Reffy's CSS prose extraction rules have been slightly updated.

Also add link to relevant issue in Reffy.