### PR TITLE
Fix workflows triggers

### DIFF
--- a/.github/workflows/prepare-css-release.yml
+++ b/.github/workflows/prepare-css-release.yml
@@ -1,13 +1,24 @@
 name: "@webref/css: Prepare release PR if needed"
 
 on:
+  # Runs on pushes to default branch on files of interest and after a crawl.
+  # Notes:
+  # - No trigger on changes to "packages/css/**" to avoid re-creating
+  # pre-release PR before package has actually been released.
+  # - Crawl pushes to default branch but that push won't trigger the workflow
+  # (a workflow cannot be triggered by a push made by another workflow). Hence
+  # the need to react on "workflow_run".
+  workflow_run:
+    workflows:
+      - "Update ED report"
+    types:
+      - completed
   push:
     branches:
       - master
     paths:
       - 'ed/css/**'
       - 'ed/csspatches/**'
-      - 'packages/css/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/prepare-idl-release.yml
+++ b/.github/workflows/prepare-idl-release.yml
@@ -1,13 +1,24 @@
 name: "@webref/idl: Prepare release PR if needed"
 
 on:
+  # Runs on pushes to default branch on files of interest and after a crawl.
+  # Notes:
+  # - No trigger on changes to "packages/css/**" to avoid re-creating
+  # pre-release PR before package has actually been released.
+  # - Crawl pushes to default branch but that push won't trigger the workflow
+  # (a workflow cannot be triggered by a push made by another workflow). Hence
+  # the need to react on "workflow_run".
+  workflow_run:
+    workflows:
+      - "Update ED report"
+    types:
+      - completed
   push:
     branches:
       - master
     paths:
       - 'ed/idl/**'
       - 'ed/idlpatches/**'
-      - 'packages/idl/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -7,12 +7,13 @@ name: "Publish @webref package if needed"
 on:
   pull_request:
     branches:
-      - 'release-*'
-    types: [closed]
+      - master
+    types:
+      - closed
 
 jobs:
   release:
-    if: github.event.pull_request.merged == true
+    if: startsWith(github.head_ref, 'release-') && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
     - name: Setup node.js


### PR DESCRIPTION
- Prevent pre-release workflows from running when pre-release PR gets merged to avoid re-creating the PR before package gets released (#223):
  There is no easy way to detect that a push was triggered by a PR merge, so hard to both react on pushes *and* not react on a specific merge at the same time. The workaround used here is not to react to changes to the file touched by the pre-release PR. That is not perfect: if one bumps the version number manually to release a major/minor version, the workflow will have to be triggered manually as well to update the pre-release PR.
  
  There may be a better solution. I propose to go ahead with this for now and leave #223 open

- Make sure pre-release workflows run after the "Update ED report" workflow has pushed updates to the default branch (#219):
  The workflows now use the "workflow_run" event. The "Update ED report" workflow may not touch files that are in CSS/IDL packages, meaning that the workflows will often run for nothing, but there's no easy way to avoid that.

- Make sure release workflow runs when pre-release PR gets merged (#222):
  The `branches` constraint [applies to the `base` branch](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestbranchestags), not to the `head`. Check on the `head` branch now done in the `if` clause.

@dontcallmedom, FYI, I ran some tests on a personal test repo to validate the triggers.