### PR TITLE
Drop now useless lerna.json file

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,0 @@
-{
-  "packages": [
-    "packages/*"
-  ],
-  "version": "independent"
-}


### PR DESCRIPTION
The file is a leftover. We no longer use lerna to manage releases to NPM.