### PR TITLE
Clean workflow: check new "elements" folder

### DIFF
--- a/tools/clean-abandoned-files.js
+++ b/tools/clean-abandoned-files.js
@@ -3,7 +3,7 @@ const fs = require("fs");
 const ed = require("../ed/index.json");
 const tr = require("../tr/index.json");
 
-const subdirs = ["dfns", "css", "headings", "idl", "idlparsed", "links", "refs"];
+const subdirs = ["dfns", "css", "elements", "headings", "idl", "idlparsed", "links", "refs"];
 const idlnamesSubdirs = ["idlnames", "idlnamesparsed"];
 
 
@@ -13,6 +13,9 @@ const removeExtension = f => {
 }
 
 function checkDir(path, index) {
+  if (!fs.existsSync(path)) {
+    return;
+  }
   const dir = fs.readdirSync(path);
   for (let filename of dir) {
     const subdir = path.split("/")[1];


### PR DESCRIPTION
Reffy now extracts HTML elements from a few specs to an "elements" folder.

This update also makes the workflow skip non-existing folders rather than crash. Typically, the `elements` folder has not yet been created under `tr` and that's normal.