### PR TITLE
Adjust workflows to release a @webref/elements package

### DIFF
--- a/.github/workflows/prepare-css-release.yml
+++ b/.github/workflows/prepare-css-release.yml
@@ -39,7 +39,7 @@ jobs:
         npm run prepare
 
     - name: Test new release
-      run: npm test
+      run: npm test-css
 
     - name: Prepare a pre-release pull request if needed
       run: node tools/prepare-release.js css

--- a/.github/workflows/prepare-elements-release.yml
+++ b/.github/workflows/prepare-elements-release.yml
@@ -1,9 +1,9 @@
-name: "@webref/idl: Prepare release PR if needed"
+name: "@webref/elements: Prepare release PR if needed"
 
 on:
   # Runs on pushes to default branch on files of interest and after a crawl.
   # Notes:
-  # - No trigger on changes to "packages/css/**" to avoid re-creating
+  # - No trigger on changes to "packages/elements/**" to avoid re-creating
   # pre-release PR before package has actually been released.
   # - Crawl pushes to default branch but that push won't trigger the workflow
   # (a workflow cannot be triggered by a push made by another workflow). Hence
@@ -17,8 +17,8 @@ on:
     branches:
       - master
     paths:
-      - 'ed/idl/**'
-      - 'ed/idlpatches/**'
+      - 'ed/elements/**'
+      - 'ed/elementspatches/**'
   workflow_dispatch:
 
 jobs:
@@ -39,9 +39,9 @@ jobs:
         npm run prepare
 
     - name: Test new release
-      run: npm test-idl
+      run: npm test-elements
 
     - name: Prepare a pre-release pull request if needed
-      run: node tools/prepare-release.js idl
+      run: node tools/prepare-release.js elements
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@ config.json
 node_modules/
 packages/css/*.json
 !packages/css/package.json
+packages/elements/*.json
+!packages/elements/package.json
 packages/idl/*.idl
 wpt/

--- a/ed/elementspatches/README.md
+++ b/ed/elementspatches/README.md
@@ -1,0 +1,5 @@
+# Element patches
+
+These are patches applied to the elements extracts scraped from specs to produce the `@webref/elements` package. These patches can break as specs are updated and thus need ongoing maintenance.
+
+For details on how to create and update patches, please see the [Web IDL patches documentation](../idlpatches/README.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -167,6 +167,10 @@
       "version": "file:packages/css",
       "dev": true
     },
+    "@webref/elements": {
+      "version": "file:packages/elements",
+      "dev": true
+    },
     "@webref/idl": {
       "version": "file:packages/idl",
       "dev": true

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@jsdevtools/npm-publish": "1.4.3",
     "@octokit/rest": "18.5.3",
     "@webref/css": "file:packages/css",
+    "@webref/elements": "file:packages/elements",
     "@webref/idl": "file:packages/idl",
     "css-tree": "1.1.2",
     "flags": "0.1.3",
@@ -36,6 +37,9 @@
   },
   "scripts": {
     "prepare": "node packages/prepare.js",
-    "test": "mocha --recursive --delay"
+    "test": "mocha --recursive --delay",
+    "test-css": "mocha --recursive --delay test/css",
+    "test-elements": "mocha --recursive --delay test/elements",
+    "test-idl": "mocha --recursive --delay test/idl"
   }
 }

--- a/packages/elements/README.md
+++ b/packages/elements/README.md
@@ -1,0 +1,44 @@
+# Markup elements of the Web platform and associated Web IDL interfaces
+
+This package contains a list per spec of markup elements that compose the Web platform, scraped from the latest versions of web platform specifications in [webref](https://github.com/w3c/webref), along with the name of the Web IDL interface that these elements implement. Fixes are applied to ensure that [guarantees](#guarantees).
+
+
+# API
+
+The async `listAll()` method resolves with an object where the keys are spec shortnames, and the values are the data for that spec. Example:
+
+```js
+const elements = require('@webref/elements');
+
+elements.listAll().then(all => {
+  for (const [shortname, data] of Object.entries(all)) {
+    // do something with the json object
+  }
+});
+```
+
+For each spec, value is an object with a `spec` property that describes the specification, and an `elements` property that lists elements defined in the spec, as an array of objects with `name` and `interface` properties. The `interface` property is not present for elements that do not implement an interface:
+
+```js
+const elements = require('@webref/elements');
+
+elements.listAll().then(all => {
+  for (const [shortname, data] of Object.entries(all)) {
+    console.log();
+    console.log(data.spec.title);
+    for (const el of data.elements) {
+      if (el.interface) {
+        console.log(`- ${el.name} implements ${el.interface}`);
+      }
+      else {
+        console.log(`- ${el.name} does not implement an interface`);
+      }
+    }
+  }
+});
+```
+
+# Guarantees
+
+The following guarantees are provided by this package:
+- All Web IDL interfaces exist in the latest version of the [`@webref/idl` package] at the time the `@webref/elements` package is released.

--- a/packages/elements/index.js
+++ b/packages/elements/index.js
@@ -1,0 +1,16 @@
+const fs = require('fs').promises;
+const path = require('path');
+
+async function listAll() {
+  const all = {};
+  const files = await fs.readdir(__dirname);
+  for (const f of files) {
+    if (f.endsWith('.json') && f !== 'package.json') {
+      const text = await fs.readFile(path.join(__dirname, f), 'utf8');
+      all[path.basename(f, '.json')] = JSON.parse(text);
+    }
+  }
+  return all;
+}
+
+module.exports = {listAll};

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@webref/elements",
+  "description": "Markup elements of the Web platform and associated Web IDL interfaces",
+  "version": "1.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/w3c/webref.git"
+  },
+  "bugs": {
+    "url": "https://github.com/w3c/webref/issues"
+  },
+  "license": "MIT",
+  "main": "index.js"
+}

--- a/packages/prepare.js
+++ b/packages/prepare.js
@@ -20,6 +20,13 @@ const packages = [
     patchDir: path.join(rootDir, 'ed/csspatches'),
     fileExt: 'json'
   },
+  {
+    name: 'elements',
+    srcDir: path.join(rootDir, 'ed/elements'),
+    dstDir: path.join(rootDir, 'packages/elements'),
+    patchDir: path.join(rootDir, 'ed/elementspatches'),
+    fileExt: 'json'
+  },
 ];
 
 

--- a/test/elements/all.js
+++ b/test/elements/all.js
@@ -1,0 +1,19 @@
+const assert = require('assert').strict;
+
+const elements = require('@webref/elements');
+
+describe('@webidl/elements module', () => {
+  it('listAll', async () => {
+    const all = await elements.listAll();
+    assert(Object.keys(all).length > 0);
+    for (const desc of Object.values(all)) {
+      assert(desc);
+      assert(desc.spec);
+      assert(desc.spec.title);
+      assert(desc.elements);
+      assert(desc.elements.length > 0);
+      assert(desc.elements[0].hasOwnProperty('name'));
+      assert(desc.elements[0].hasOwnProperty('interface'));
+    }
+  });
+});

--- a/test/elements/consistency.js
+++ b/test/elements/consistency.js
@@ -1,0 +1,32 @@
+const assert = require('assert').strict;
+
+const elements = require('@webref/elements');
+const idl = require('@webref/idl');
+
+idl.parseAll().then(allIdl => {
+  // Create a set of well-known interfaces
+  const interfaces = new Set();
+  for (const [shortname, ast] of Object.entries(allIdl)) {
+    for (const dfn of ast) {
+      if (dfn.name) {
+        interfaces.add(dfn.name);
+      }
+    }
+  }
+
+  return elements.listAll().then(allElements => {
+    for (const [shortname, data] of Object.entries(allElements)) {
+      console.log(shortname);
+      describe(`The ${shortname} entry in @webidl/elements`, () => {
+        for (const el of data.elements) {
+          if (!el.interface) {
+            continue;
+          }
+          it(`links to a well-known interface for "${el.name}"`, () => {
+            assert(interfaces.has(el.interface), `Unknown interface "${el.interface}"`);
+          });
+        }
+      });
+    }
+  });
+}).then(run);

--- a/tools/prepare-release.js
+++ b/tools/prepare-release.js
@@ -1,8 +1,8 @@
 /**
- * Prepare a CSS or IDL package release pull request.
+ * Prepare a Webref package release pull request if needed.
  *
- * The pull request contains the CSS or IDL diff as description, and bumps the
- * version patch number.
+ * The pull request contains the diff as description, and bumps the version
+ * patch number.
  *
  * If the PR is merged, the "release-package.js" job should run and actually
  * release the package at the commit on which the pre-release PR was based.
@@ -43,7 +43,8 @@ function btoa(str) {
  * Compute diff between the released npm package and the contents of the repo
  *
  * @function
- * @param {String} type Package name. One of "css" or "idl"
+ * @param {String} type Package name. Must match one of the existing folder
+ *  names under "packages" (e.g. "css", "elements", "idl")
  * @return {String} The results of running the diff. An empty string if contents
  *   match.
  */
@@ -128,7 +129,8 @@ function computeDiff(type) {
  * Create or update pre-release pull request
  *
  * @function
- * @param {String} type Package name. One of "css" or "idl"
+ * @param {String} type Package name. Must match one of the existing folder
+ *  names under "packages" (e.g. "css", "elements", "idl")
  */
 async function prepareRelease(type) {
   // Compute a reasonably unique ID
@@ -336,7 +338,7 @@ const octokit = new Octokit({
   //log: console
 });
 
-const packageType = (process.argv[2] === "css") ? "css": "idl";
+const packageType = process.argv[2] ?? "idl";
 
 prepareRelease(packageType)
   .then(() => {

--- a/tools/release-package.js
+++ b/tools/release-package.js
@@ -1,5 +1,5 @@
 /**
- * Publish CSS or IDL package to npm, using the commit on which the pre-release
+ * Publish a Webref package to npm, using the commit on which the pre-release
  * PR is based.
  */
 
@@ -42,7 +42,7 @@ async function releasePackage(prNumber) {
   }
   const type = match[1];
 
-  if (!["css", "idl"].includes(type)) {
+  if (!["css", "elements", "idl"].includes(type)) {
     console.log(`- Unknown package type "${type}", nothing to release`);
     return;
   }

--- a/tools/request-pr-review.js
+++ b/tools/request-pr-review.js
@@ -14,7 +14,7 @@ const reviewers = ["dontcallmedom", "foolip", "tidoust"];
  * Create or update pre-release pull request
  *
  * @function
- * @param {String} type Package name. One of "css" or "idl"
+ * @param {String} type Package name
  */
 async function requestReview(type) {
   console.log(`Check pre-release PR for the @webref/${type} package`);
@@ -75,9 +75,9 @@ const octokit = new Octokit({
   //log: console
 });
 
-const packageType = (process.argv[2] === "css") ? "css": "idl";
-
 requestReview("css")
+  .then(() => console.log())
+  .then(() => requestReview("elements"))
   .then(() => console.log())
   .then(() => requestReview("idl"))
   .then(() => {


### PR DESCRIPTION
This adjusts workflows to also handle and release a `@webref/elements` package, as discussed in #51. Tests guarantee that interfaces that appear in the package also exist in the `@webref/idl`.

Ideally, the IDL package should be added as peer dependency to the elements package but that creates a chicken-and-egg situation as we will likely often release packages together.

Patches are an overkill for now but could prove useful in the long run.

The update also splits CSS, elements, and IDL tests. That is a first step towards addressing #237. It does not fully solve it though, as IDL patches are still applied when the CSS package is released.