### PR TITLE
Bump minor version of @webref/css package

### DIFF
--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@webref/css",
   "description": "CSS definitions of the web platform",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/w3c/webref.git"


### PR DESCRIPTION
The `styleDeclaration` property did not exist before #246.