### PR TITLE
Add IDL patch for WebGPU

### DIFF
--- a/ed/idlpatches/webgpu.idl.patch
+++ b/ed/idlpatches/webgpu.idl.patch
@@ -1,0 +1,54 @@
+From aed7f4a9667b43852751f72d7f4067427dfe3b45 Mon Sep 17 00:00:00 2001
+From: Francois Daoust <fd@tidoust.net>
+Date: Wed, 9 Jun 2021 09:08:23 +0200
+Subject: [PATCH] Rollback to GPUCanvasContext
+
+https://github.com/gpuweb/gpuweb/issues/1822
+---
+ ed/idl/webgpu.idl | 15 ++++++++++-----
+ 1 file changed, 10 insertions(+), 5 deletions(-)
+
+diff --git a/ed/idl/webgpu.idl b/ed/idl/webgpu.idl
+index 05651e3de..0eaf4bb2f 100644
+--- a/ed/idl/webgpu.idl
++++ b/ed/idl/webgpu.idl
+@@ -980,11 +980,10 @@ enum GPUPipelineStatisticName {
+ };
+ 
+ [Exposed=Window]
+-interface GPUPresentationContext {
+-    undefined configure(GPUPresentationConfiguration? configuration);
++interface GPUCanvasContext {
++    GPUSwapChain configureSwapChain(GPUSwapChainDescriptor descriptor);
+ 
+-    GPUTextureFormat getPreferredFormat(GPUAdapter adapter);
+-    GPUTexture getCurrentTexture();
++    GPUTextureFormat getSwapChainPreferredFormat(GPUAdapter adapter);
+ };
+ 
+ enum GPUCanvasCompositingAlphaMode {
+@@ -992,7 +991,7 @@ enum GPUCanvasCompositingAlphaMode {
+     "premultiplied",
+ };
+ 
+-dictionary GPUPresentationConfiguration : GPUObjectDescriptorBase {
++dictionary GPUSwapChainDescriptor : GPUObjectDescriptorBase {
+     required GPUDevice device;
+     required GPUTextureFormat format;
+     GPUTextureUsageFlags usage = 0x10;  // GPUTextureUsage.RENDER_ATTACHMENT
+@@ -1000,6 +999,12 @@ dictionary GPUPresentationConfiguration : GPUObjectDescriptorBase {
+     GPUExtent3D size;
+ };
+ 
++[Exposed=Window]
++interface GPUSwapChain {
++    GPUTexture getCurrentTexture();
++};
++GPUSwapChain includes GPUObjectBase;
++
+ enum GPUDeviceLostReason {
+     "destroyed",
+ };
+-- 
+2.31.1.windows.1
+


### PR DESCRIPTION
The patch rolls the IDL extract back to what it was before the problem was created.