### PR TITLE
Clean patches workflow: Fix RegExp for issue extraction

### DIFF
--- a/tools/clean-patches.js
+++ b/tools/clean-patches.js
@@ -40,7 +40,7 @@ async function dropPatchesWhenPossible() {
   console.log();
   console.log("Extract list of issues");
   const diffStart = /^---$/m;
-  const issueUrl = /(?:^|\s)https:\/\/github\.com\/([^\/]+)\/([^\/]+)\/(issues|pull)\/(\d+)(?:\s|$)/g;
+  const issueUrl = /(?<=^|\s)https:\/\/github\.com\/([^\/]+)\/([^\/]+)\/(issues|pull)\/(\d+)(?=\s|$)/g;
   for (const patch of patches) {
     const contents = fs.readFileSync(path.join(rootDir, patch.name), "utf8");
     const desc = contents.substring(0, contents.match(diffStart)?.index);


### PR DESCRIPTION
The workflow failed to detect a second issue URL on the following line on systems that have `\n` as line separator (I had not detected that issue because my system uses `\r\n`...)

The fix is to use lookahead and lookbehind assertions in the RegExp instead of non-capturing groups, so as not to "consume" bounding characters.

This fixes the issue detected in #274.