### PR TITLE
Major version bump for @webref/css package

### DIFF
--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@webref/css",
   "description": "CSS definitions of the web platform",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/w3c/webref.git"


### PR DESCRIPTION
Structure changed for the CSS "descriptors", which are now returned in an array.