### PR TITLE
Update IDL patch for Web Animations

### DIFF
--- a/ed/idlpatches/web-animations-2.idl.patch
+++ b/ed/idlpatches/web-animations-2.idl.patch
@@ -1,6 +1,6 @@
-From 02c8a7920291c53ab07942930c4234c240aff8f1 Mon Sep 17 00:00:00 2001
+From 7bcaa17bb3609a233727d8964f6bc310deecc830 Mon Sep 17 00:00:00 2001
 From: Francois Daoust <fd@tidoust.net>
-Date: Thu, 6 May 2021 15:32:18 +0200
+Date: Thu, 24 Jun 2021 10:22:36 +0200
 Subject: [PATCH] Drop duplicate `fillMode` enum definition
 
 The spec is a delta spec and re-defines that enum because it updates the meaning
@@ -11,11 +11,11 @@ the spec remains a delta spec.
  1 file changed, 2 deletions(-)
 
 diff --git a/ed/idl/web-animations-2.idl b/ed/idl/web-animations-2.idl
-index 628282743..bf4f9aa18 100644
+index 1b5db8b13..2bc7aa412 100644
 --- a/ed/idl/web-animations-2.idl
 +++ b/ed/idl/web-animations-2.idl
-@@ -33,8 +33,6 @@ partial dictionary ComputedEffectTiming {
-     double startTime;
+@@ -38,8 +38,6 @@ partial dictionary ComputedEffectTiming {
+     CSSNumberish?        progress;
  };
  
 -enum FillMode { "none", "forwards", "backwards", "both", "auto" };
@@ -24,5 +24,5 @@ index 628282743..bf4f9aa18 100644
  interface GroupEffect {
    constructor(sequence<AnimationEffect>? children,
 -- 
-2.31.0.windows.1
+2.32.0.windows.1
 

--- a/ed/idlpatches/web-animations-2.idl.patch
+++ b/ed/idlpatches/web-animations-2.idl.patch
@@ -1,23 +1,31 @@
-From 7bcaa17bb3609a233727d8964f6bc310deecc830 Mon Sep 17 00:00:00 2001
+From cba91c8b29368e2f9886a05c9c5456deda4fccc5 Mon Sep 17 00:00:00 2001
 From: Francois Daoust <fd@tidoust.net>
-Date: Thu, 24 Jun 2021 10:22:36 +0200
-Subject: [PATCH] Drop duplicate `fillMode` enum definition
+Date: Thu, 24 Jun 2021 10:33:56 +0200
+Subject: [PATCH] Drop duplicate `fillMode` and `ComputedEffectTiming` dfns
 
-The spec is a delta spec and re-defines that enum because it updates the meaning
-of one of its values. Patch will likely need to be kept around for as long as
-the spec remains a delta spec.
+The spec is a delta spec and re-defines these dfns to update their meaning and
+complete members and values. Patch will likely need to be kept around for as
+long as the spec remains a delta spec.
 ---
- ed/idl/web-animations-2.idl | 2 --
- 1 file changed, 2 deletions(-)
+ ed/idl/web-animations-2.idl | 10 ----------
+ 1 file changed, 10 deletions(-)
 
 diff --git a/ed/idl/web-animations-2.idl b/ed/idl/web-animations-2.idl
-index 1b5db8b13..2bc7aa412 100644
+index 1b5db8b13..ba7c860c2 100644
 --- a/ed/idl/web-animations-2.idl
 +++ b/ed/idl/web-animations-2.idl
-@@ -38,8 +38,6 @@ partial dictionary ComputedEffectTiming {
-     CSSNumberish?        progress;
+@@ -30,16 +30,6 @@ partial dictionary OptionalEffectTiming {
+     double playbackRate;
  };
  
+-partial dictionary ComputedEffectTiming {
+-    CSSNumberish         startTime;
+-    CSSNumberish         endTime;
+-    CSSNumberish         activeDuration;
+-    CSSNumberish?        localTime;
+-    CSSNumberish?        progress;
+-};
+-
 -enum FillMode { "none", "forwards", "backwards", "both", "auto" };
 -
  [Exposed=Window]

--- a/ed/idlpatches/web-animations-2.idl.patch
+++ b/ed/idlpatches/web-animations-2.idl.patch
@@ -1,31 +1,35 @@
-From cba91c8b29368e2f9886a05c9c5456deda4fccc5 Mon Sep 17 00:00:00 2001
+From c23c657bba54488f8223ef05634aa1a12bd172bb Mon Sep 17 00:00:00 2001
 From: Francois Daoust <fd@tidoust.net>
-Date: Thu, 24 Jun 2021 10:33:56 +0200
-Subject: [PATCH] Drop duplicate `fillMode` and `ComputedEffectTiming` dfns
+Date: Thu, 24 Jun 2021 10:55:15 +0200
+Subject: [PATCH] Drop duplicate `fillMode` enum, fix `ComputedEffectTiming`
 
-The spec is a delta spec and re-defines these dfns to update their meaning and
-complete members and values. Patch will likely need to be kept around for as
-long as the spec remains a delta spec.
+The spec is a delta spec and re-defines the enum to change the meaning of one of
+its value. It also extends but also modifies the definition of the
+`ComputedEffectTiming` dictionary.
+
+Patch will likely need to be kept around for as long as the spec remains a delta
+spec.
 ---
- ed/idl/web-animations-2.idl | 10 ----------
- 1 file changed, 10 deletions(-)
+ ed/idl/web-animations-2.idl | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
 
 diff --git a/ed/idl/web-animations-2.idl b/ed/idl/web-animations-2.idl
-index 1b5db8b13..ba7c860c2 100644
+index 1b5db8b13..c03be662d 100644
 --- a/ed/idl/web-animations-2.idl
 +++ b/ed/idl/web-animations-2.idl
-@@ -30,16 +30,6 @@ partial dictionary OptionalEffectTiming {
+@@ -30,7 +30,7 @@ partial dictionary OptionalEffectTiming {
      double playbackRate;
  };
  
 -partial dictionary ComputedEffectTiming {
--    CSSNumberish         startTime;
--    CSSNumberish         endTime;
--    CSSNumberish         activeDuration;
--    CSSNumberish?        localTime;
--    CSSNumberish?        progress;
--};
--
++dictionary ComputedEffectTiming {
+     CSSNumberish         startTime;
+     CSSNumberish         endTime;
+     CSSNumberish         activeDuration;
+@@ -38,8 +38,6 @@ partial dictionary ComputedEffectTiming {
+     CSSNumberish?        progress;
+ };
+ 
 -enum FillMode { "none", "forwards", "backwards", "both", "auto" };
 -
  [Exposed=Window]

--- a/ed/idlpatches/web-animations.idl.patch
+++ b/ed/idlpatches/web-animations.idl.patch
@@ -1,0 +1,34 @@
+From 19b9c8dc7f45c366acc866426d1a84da5a6a44bf Mon Sep 17 00:00:00 2001
+From: Francois Daoust <fd@tidoust.net>
+Date: Thu, 24 Jun 2021 10:58:08 +0200
+Subject: [PATCH] Drop duplicate `ComputedEffectTiming` dfn
+
+The dictionary is re-defined in Level 2 with an additional property and
+different property types. Patch is only needed because Level 2 is a delta spec.
+It will likely need to be kept around for as long as that remains the case.
+---
+ ed/idl/web-animations.idl | 8 --------
+ 1 file changed, 8 deletions(-)
+
+diff --git a/ed/idl/web-animations.idl b/ed/idl/web-animations.idl
+index 6e973d195..a9675b1d9 100644
+--- a/ed/idl/web-animations.idl
++++ b/ed/idl/web-animations.idl
+@@ -85,14 +85,6 @@ enum FillMode { "none", "forwards", "backwards", "both", "auto" };
+ 
+ enum PlaybackDirection { "normal", "reverse", "alternate", "alternate-reverse" };
+ 
+-dictionary ComputedEffectTiming : EffectTiming {
+-    unrestricted double  endTime;
+-    unrestricted double  activeDuration;
+-    double?              localTime;
+-    double?              progress;
+-    unrestricted double? currentIteration;
+-};
+-
+ [Exposed=Window]
+ interface KeyframeEffect : AnimationEffect {
+     constructor(Element? target,
+-- 
+2.32.0.windows.1
+


### PR DESCRIPTION
Patch is still needed but IDL right before the patch got changed in the spec invalidating the previous patch.