### PR TITLE
Release workflow: Install deps individually

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -27,7 +27,10 @@ jobs:
         ref: master
 
     - name: Install dependencies
-      run: npm ci
+      run: |
+        npm install --no-save @octokit/rest
+        npm install --no-save rimraf
+        npm install --no-save @jsdevtools/npm-publish
 
     - name: Release package if needed
       run: node tools/release-package.js ${{ github.event.pull_request.number }}


### PR DESCRIPTION
To run the release script, the release workflow installed dependencies with an `npm ci` call. Problem is that this triggers the prepare script as well, applying CSS/IDL patches. If some patch is no longer valid because the underlying spec got modified in the meantime, the workflow fails as a result.

That's a pity because the workflow does not depend on patches in practice. This update installs deps that the workflow needs individually to avoid applying patches.