### PR TITLE
Restore ComputedEffectTiming.currentIteration etc.

### DIFF
--- a/ed/idlpatches/web-animations-2.idl.patch
+++ b/ed/idlpatches/web-animations-2.idl.patch
@@ -1,31 +1,21 @@
-From c23c657bba54488f8223ef05634aa1a12bd172bb Mon Sep 17 00:00:00 2001
-From: Francois Daoust <fd@tidoust.net>
-Date: Thu, 24 Jun 2021 10:55:15 +0200
-Subject: [PATCH] Drop duplicate `fillMode` enum, fix `ComputedEffectTiming`
+From ea2e5beb27b21ea54c3633c0282e71f1d9e14393 Mon Sep 17 00:00:00 2001
+From: Kagami Sascha Rosylight <saschanaz@outlook.com>
+Date: Thu, 1 Jul 2021 13:35:40 +0200
+Subject: [PATCH] Drop duplicate `fillMode` enum definition
 
 The spec is a delta spec and re-defines the enum to change the meaning of one of
-its value. It also extends but also modifies the definition of the
-`ComputedEffectTiming` dictionary.
+its values.
 
 Patch will likely need to be kept around for as long as the spec remains a delta
 spec.
 ---
- ed/idl/web-animations-2.idl | 4 +---
- 1 file changed, 1 insertion(+), 3 deletions(-)
+ ed/idl/web-animations-2.idl | 2 --
+ 1 file changed, 2 deletions(-)
 
 diff --git a/ed/idl/web-animations-2.idl b/ed/idl/web-animations-2.idl
-index 1b5db8b13..c03be662d 100644
+index 1b5db8b13..2bc7aa412 100644
 --- a/ed/idl/web-animations-2.idl
 +++ b/ed/idl/web-animations-2.idl
-@@ -30,7 +30,7 @@ partial dictionary OptionalEffectTiming {
-     double playbackRate;
- };
- 
--partial dictionary ComputedEffectTiming {
-+dictionary ComputedEffectTiming {
-     CSSNumberish         startTime;
-     CSSNumberish         endTime;
-     CSSNumberish         activeDuration;
 @@ -38,8 +38,6 @@ partial dictionary ComputedEffectTiming {
      CSSNumberish?        progress;
  };

--- a/ed/idlpatches/web-animations.idl.patch
+++ b/ed/idlpatches/web-animations.idl.patch
@@ -1,34 +1,30 @@
-From 19b9c8dc7f45c366acc866426d1a84da5a6a44bf Mon Sep 17 00:00:00 2001
-From: Francois Daoust <fd@tidoust.net>
-Date: Thu, 24 Jun 2021 10:58:08 +0200
+From ab2e615380eee3c617fa06e16f1007ffa340d0e1 Mon Sep 17 00:00:00 2001
+From: Kagami Sascha Rosylight <saschanaz@outlook.com>
+Date: Thu, 1 Jul 2021 13:33:00 +0200
 Subject: [PATCH] Drop duplicate `ComputedEffectTiming` dfn
 
 The dictionary is re-defined in Level 2 with an additional property and
 different property types. Patch is only needed because Level 2 is a delta spec.
 It will likely need to be kept around for as long as that remains the case.
 ---
- ed/idl/web-animations.idl | 8 --------
- 1 file changed, 8 deletions(-)
+ ed/idl/web-animations.idl | 4 ----
+ 1 file changed, 4 deletions(-)
 
 diff --git a/ed/idl/web-animations.idl b/ed/idl/web-animations.idl
-index 6e973d195..a9675b1d9 100644
+index 6e973d195..626c82356 100644
 --- a/ed/idl/web-animations.idl
 +++ b/ed/idl/web-animations.idl
-@@ -85,14 +85,6 @@ enum FillMode { "none", "forwards", "backwards", "both", "auto" };
- 
+@@ -86,10 +86,6 @@ enum FillMode { "none", "forwards", "backwards", "both", "auto" };
  enum PlaybackDirection { "normal", "reverse", "alternate", "alternate-reverse" };
  
--dictionary ComputedEffectTiming : EffectTiming {
+ dictionary ComputedEffectTiming : EffectTiming {
 -    unrestricted double  endTime;
 -    unrestricted double  activeDuration;
 -    double?              localTime;
 -    double?              progress;
--    unrestricted double? currentIteration;
--};
--
- [Exposed=Window]
- interface KeyframeEffect : AnimationEffect {
-     constructor(Element? target,
+     unrestricted double? currentIteration;
+ };
+ 
 -- 
 2.32.0.windows.1
 


### PR DESCRIPTION
This mostly reverts #285 to restore the now-missing member `currentIteration` and the inheritance from `EffectTiming`.