### PR TITLE
Drop SVG 1.1 elements and IDL deprecated in SVG 2

### DIFF
--- a/ed/elementspatches/SVG11.json.patch
+++ b/ed/elementspatches/SVG11.json.patch
@@ -1,17 +1,19 @@
-From b439b3472862e5de769058366cc42f3480651d15 Mon Sep 17 00:00:00 2001
+From ffbc27e5547fc329522bb35a113d051d5a0ef7ec Mon Sep 17 00:00:00 2001
 From: Francois Daoust <fd@tidoust.net>
-Date: Fri, 18 Jun 2021 17:31:41 +0200
-Subject: [PATCH] Drop non implemented SVG 1.1 only elements
+Date: Wed, 7 Jul 2021 10:53:15 +0200
+Subject: [PATCH] Drop SVG 1.1 elements deprecated in SVG 2
 
+Note `<clipPath>` and `<mask>` are not defined in SVG 2 but they are defined in
+CSS Masking Level 1.
 ---
- ed/elements/SVG11.json | 56 ------------------------------------------
- 1 file changed, 56 deletions(-)
+ ed/elements/SVG11.json | 72 ------------------------------------------
+ 1 file changed, 72 deletions(-)
 
 diff --git a/ed/elements/SVG11.json b/ed/elements/SVG11.json
-index f625f0541..c030834b3 100644
+index f625f0541..d085ab508 100644
 --- a/ed/elements/SVG11.json
 +++ b/ed/elements/SVG11.json
-@@ -80,10 +80,6 @@
+@@ -80,38 +80,14 @@
        "name": "tspan",
        "interface": "SVGTSpanElement"
      },
@@ -22,10 +24,11 @@ index f625f0541..c030834b3 100644
      {
        "name": "textPath",
        "interface": "SVGTextPathElement"
-@@ -92,14 +88,6 @@
-       "name": "altGlyph",
-       "interface": "SVGAltGlyphElement"
      },
+-    {
+-      "name": "altGlyph",
+-      "interface": "SVGAltGlyphElement"
+-    },
 -    {
 -      "name": "altGlyphDef",
 -      "interface": "SVGAltGlyphDefElement"
@@ -34,10 +37,11 @@ index f625f0541..c030834b3 100644
 -      "name": "altGlyphItem",
 -      "interface": "SVGAltGlyphItemElement"
 -    },
+-    {
+-      "name": "glyphRef",
+-      "interface": "SVGGlyphRefElement"
+-    },
      {
-       "name": "glyphRef",
-       "interface": "SVGGlyphRefElement"
-@@ -108,10 +96,6 @@
        "name": "marker",
        "interface": "SVGMarkerElement"
      },
@@ -48,7 +52,18 @@ index f625f0541..c030834b3 100644
      {
        "name": "linearGradient",
        "interface": "SVGLinearGradientElement"
-@@ -268,10 +252,6 @@
+@@ -236,10 +212,6 @@
+       "name": "feTurbulence",
+       "interface": "SVGFETurbulenceElement"
+     },
+-    {
+-      "name": "cursor",
+-      "interface": "SVGCursorElement"
+-    },
+     {
+       "name": "a",
+       "interface": "SVGAElement"
+@@ -268,54 +240,10 @@
        "name": "mpath",
        "interface": "SVGMPathElement"
      },
@@ -59,10 +74,11 @@ index f625f0541..c030834b3 100644
      {
        "name": "animateTransform",
        "interface": "SVGAnimateTransformElement"
-@@ -280,42 +260,6 @@
-       "name": "font",
-       "interface": "SVGFontElement"
      },
+-    {
+-      "name": "font",
+-      "interface": "SVGFontElement"
+-    },
 -    {
 -      "name": "glyph",
 -      "interface": "SVGGlyphElement"

--- a/ed/idlpatches/SVG.idl.patch
+++ b/ed/idlpatches/SVG.idl.patch
@@ -1,18 +1,18 @@
-From 00f03dfcfa40e90574b0285de758eb153c993aa5 Mon Sep 17 00:00:00 2001
-From: Francois Daoust <fd@tidoust.net>
-Date: Fri, 18 Jun 2021 17:30:02 +0200
-Subject: [PATCH] Fix SVG.idl / Add SVG 1.1 only interfaces
+From 28b67fca45cca9a2029a5c1321d74ce9b0a31a93 Mon Sep 17 00:00:00 2001
+From: Kagami Sascha Rosylight <saschanaz@outlook.com>
+Date: Fri, 12 Mar 2021 06:48:07 +0100
+Subject: [PATCH] Fix SVG.idl
 
 HTMLHyperlinkElementUtils: https://github.com/w3c/svgwg/issues/312
 ---
- ed/idl/SVG.idl | 51 +++++++++++++++++++++++++++++++++++++++++++++++++-
- 1 file changed, 50 insertions(+), 1 deletion(-)
+ ed/idl/SVG.idl | 15 ++++++++++++++-
+ 1 file changed, 14 insertions(+), 1 deletion(-)
 
 diff --git a/ed/idl/SVG.idl b/ed/idl/SVG.idl
-index 9ce619d1e..7077e4ecd 100644
+index e0b013bfa..69d47018e 100644
 --- a/ed/idl/SVG.idl
 +++ b/ed/idl/SVG.idl
-@@ -673,9 +673,58 @@ interface SVGAElement : SVGGraphicsElement {
+@@ -672,7 +672,20 @@ interface SVGAElement : SVGGraphicsElement {
  };
  
  SVGAElement includes SVGURIReference;
@@ -34,44 +34,6 @@ index 9ce619d1e..7077e4ecd 100644
  
  [Exposed=Window]
  interface SVGViewElement : SVGElement {};
- 
- SVGViewElement includes SVGFitToViewBox;
-+
-+
-+////////////////////////////////////////////////////////////////////////////////
-+// SVG 1.1 interfaces that do not exist in SVG 2 and that are still implemented.
-+//
-+// Note this is best effort at defining these interfaces with current Web IDL,
-+// as the actual definitions in SVG 1.1 use outdated (and invalid) IDL.
-+////////////////////////////////////////////////////////////////////////////////
-+[Exposed=Window]
-+interface SVGAltGlyphElement : SVGTextPositioningElement {
-+  attribute DOMString glyphRef;
-+  attribute DOMString format;
-+};
-+SVGAltGlyphElement includes SVGURIReference;
-+
-+[Exposed=Window]
-+interface SVGGlyphRefElement : SVGElement {
-+  attribute DOMString glyphRef;
-+  attribute DOMString format;
-+  attribute float x;
-+  attribute float y;
-+  attribute float dx;
-+  attribute float dy;
-+};
-+SVGGlyphRefElement includes SVGURIReference;
-+
-+[Exposed=Window]
-+interface SVGCursorElement : SVGElement {
-+  readonly attribute SVGAnimatedLength x;
-+  readonly attribute SVGAnimatedLength y;
-+};
-+SVGCursorElement includes SVGURIReference;
-+SVGCursorElement includes SVGTests;
-+
-+[Exposed=Window]
-+interface SVGFontElement : SVGElement {};
 -- 
-2.31.1.windows.1
+2.30.0.windows.1
 


### PR DESCRIPTION
See rationale in https://github.com/w3c/webref/issues/278#issuecomment-874168240

This update keeps SVG 1.1 elements that still exist and rolls back the IDL patch on SVG 2 to what it used to be before SVG 1.1 only interfaces got added to it.

Fixes #278.