### PR TITLE
Update workflows: adjust checkout branch for Reffy

### DIFF
--- a/.github/workflows/update-ed.yml
+++ b/.github/workflows/update-ed.yml
@@ -11,7 +11,7 @@ jobs:
       uses: actions/checkout@master
       with:
         repository: w3c/reffy
-        ref: master
+        ref: main
         fetch-depth: 1
         path: reffy
     - name: Setup node.js

--- a/.github/workflows/update-tr.yml
+++ b/.github/workflows/update-tr.yml
@@ -11,7 +11,7 @@ jobs:
       uses: actions/checkout@master
       with:
         repository: w3c/reffy
-        ref: master
+        ref: main
         fetch-depth: 1
         path: reffy
     - name: Setup node.js

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
 
     <section>
       <h2>About Reffy</h2>
-      <p>Reffy was initially created by <a href="https://github.com/tidoust/">François Daoust</a> and <a href="https://github.com/dontcallmedom/">Dominique Hazaël-Massieux</a> during the 2016 edition of the <a href="https://www.w3.org/blog/2016/07/exploring-web-platform-cross-dependencies/">W3C Geek Week</a>, and updated during the 2017 edition of that same W3C Geek Week. Code and instructions are available on <a href="https://github.com/w3c/reffy" title="Reffy repository on GitHub">GitHub</a>. Feel free to report bugs  The code is available under an <a href="https://github.com/w3c/reffy/blob/master/LICENSE">MIT license</a>.</p>
+      <p>Reffy was initially created by <a href="https://github.com/tidoust/">François Daoust</a> and <a href="https://github.com/dontcallmedom/">Dominique Hazaël-Massieux</a> during the 2016 edition of the <a href="https://www.w3.org/blog/2016/07/exploring-web-platform-cross-dependencies/">W3C Geek Week</a>, and updated during the 2017 edition of that same W3C Geek Week. Code and instructions are available on <a href="https://github.com/w3c/reffy" title="Reffy repository on GitHub">GitHub</a>. Feel free to report bugs. The code is available under an <a href="https://github.com/w3c/reffy/blob/main/LICENSE">MIT license</a>.</p>
     </section>
   </body>
 </html>


### PR DESCRIPTION
Needed following switch to "main" in Reffy.

I note that most workflows currently reference live versions of actions, which isn't too good. I'll prepare another PR to address that.