### PR TITLE
Use explicit versions for actions

### DIFF
--- a/.github/workflows/clean-patches.yml
+++ b/.github/workflows/clean-patches.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - name: Checkout webref
-      uses: actions/checkout@master
+      uses: actions/checkout@v2
 
     - name: Setup node.js
-      uses: actions/setup-node@master
+      uses: actions/setup-node@v2
       with:
-        node-version: 14.x
+        node-version: '14'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - name: Checkout webref
-      uses: actions/checkout@master
+      uses: actions/checkout@v2
     - name: Setup node.js
-      uses: actions/setup-node@master
+      uses: actions/setup-node@v2
       with:
-        node-version: 10.x
+        node-version: '14'
     - name: Run clean up
       run: node tools/clean-abandoned-files.js
     - uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/prepare-css-release.yml
+++ b/.github/workflows/prepare-css-release.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@v2
       with:
-        node-version: 14.x
+        node-version: '14'
 
     - name: Checkout webref
       uses: actions/checkout@v2

--- a/.github/workflows/prepare-elements-release.yml
+++ b/.github/workflows/prepare-elements-release.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@v2
       with:
-        node-version: 14.x
+        node-version: '14'
 
     - name: Checkout webref
       uses: actions/checkout@v2

--- a/.github/workflows/prepare-idl-release.yml
+++ b/.github/workflows/prepare-idl-release.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@v2
       with:
-        node-version: 14.x
+        node-version: '14'
 
     - name: Checkout webref
       uses: actions/checkout@v2

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@v2
       with:
-        node-version: 14.x
+        node-version: '14'
 
     - name: Checkout latest version of release script
       uses: actions/checkout@v2

--- a/.github/workflows/request-pr-review.yml
+++ b/.github/workflows/request-pr-review.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@v2
       with:
-        node-version: 14.x
+        node-version: '14'
 
     - name: Checkout webref
       uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: 14.x
+        node-version: '14'
     - run: npm ci
     - run: npm test
 env:

--- a/.github/workflows/update-ed.yml
+++ b/.github/workflows/update-ed.yml
@@ -8,16 +8,16 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - name: Checkout reffy
-      uses: actions/checkout@master
+      uses: actions/checkout@v2
       with:
         repository: w3c/reffy
         ref: main
         fetch-depth: 1
         path: reffy
     - name: Setup node.js
-      uses: actions/setup-node@master
+      uses: actions/setup-node@v2
       with:
-        node-version: 14.x
+        node-version: '14'
     - name: Install pandoc
       run: sudo apt-get install pandoc
     - name: Setup Reffy
@@ -28,7 +28,7 @@ jobs:
       run: npm run ed
       working-directory: reffy
     - name: Checkout webref
-      uses: actions/checkout@master
+      uses: actions/checkout@v2
       with:
         path: webref
     - name: Copy reports

--- a/.github/workflows/update-tr.yml
+++ b/.github/workflows/update-tr.yml
@@ -8,16 +8,16 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - name: Checkout reffy
-      uses: actions/checkout@master
+      uses: actions/checkout@v2
       with:
         repository: w3c/reffy
         ref: main
         fetch-depth: 1
         path: reffy
     - name: Setup node.js
-      uses: actions/setup-node@master
+      uses: actions/setup-node@v2
       with:
-        node-version: 14.x
+        node-version: '14'
     - name: Install pandoc
       run: sudo apt-get install pandoc
     - name: Setup Reffy
@@ -28,7 +28,7 @@ jobs:
       run: npm run tr
       working-directory: reffy
     - name: Checkout webref
-      uses: actions/checkout@master
+      uses: actions/checkout@v2
       with:
         path: webref
     - name: Copy reports


### PR DESCRIPTION
Workflows referenced live versions of actions, which isn't the recommended way to reference actions:

"We strongly recommend that you include the version of the action you are using by specifying a Git ref, SHA, or Docker tag number. If you don't specify a version, it could break your workflows or cause unexpected behavior when the action owner publishes an update."
https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsuses

The update also defaults to the documented way to reference the version of Node.js.