### PR TITLE
Delete secure-contexts IDL extract

### DIFF
--- a/ed/idl/secure-contexts.idl
+++ b/ed/idl/secure-contexts.idl
@@ -1,8 +1,0 @@
-// GENERATED CONTENT - DO NOT EDIT
-// Content was automatically extracted by Reffy into webref
-// (https://github.com/w3c/webref)
-// Source: Secure Contexts (https://w3c.github.io/webappsec-secure-contexts/)
-
-partial interface WindowOrWorkerGlobalScope {
-  readonly attribute boolean isSecureContext;
-};


### PR DESCRIPTION
Spec was temporarily published with IDL that has already been integrated in HTML yesterday.

Plus the WebIDL is invalid (should be "partial interface **mixin**").