### PR TITLE
Add small CLI tool to semi-automate creation of patches

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "webidl2": "24.0.1"
   },
   "scripts": {
+    "create-patch": "node tools/create-patch.js",
     "prepare": "node packages/prepare.js",
     "test": "mocha --recursive --delay",
     "test-css": "mocha --recursive --delay test/css",

--- a/tools/create-patch.js
+++ b/tools/create-patch.js
@@ -1,0 +1,71 @@
+/**
+ * Create a patch from last commit in current branch provided it touched one
+ * CSS, elements, or IDL extract file, rollback that commit, copy the patch file
+ * to ed/[xxx]patches as needed, and commit the file in a new branch, leaving
+ * just a few manual steps to actually integrate the patch into Webref.
+ * 
+ * node tools/create-patch.js
+ */
+
+const util = require('util');
+const path = require('path');
+const exec = util.promisify(require('child_process').exec);
+const execFile = util.promisify(require('child_process').execFile);
+
+async function main() {
+  console.log('Check last commit touches one and only one CSS/Elements/IDL file...');
+  const { stdout: diffOut } = await execFile('git', ['diff', '--name-only', 'HEAD', 'HEAD~1']);
+  const files = diffOut.split(/[\r\n]/).filter(f => !!f);
+  if (files.length !== 1) {
+    throw new Error('Last commit should only touch one CSS/Elements/IDL file');
+  }
+  const commitFile = files[0];
+  if (!commitFile.startsWith('ed/idl/') &&
+      !commitFile.startsWith('ed/css/') &&
+      !commitFile.startsWith('ed/elements/')) {
+    throw new Error('Last commit did not touch a CSS/Elements/IDL file');
+  }
+  const patchType = commitFile.startsWith('ed/idl/') ? 'idl' :
+    commitFile.startsWith('ed/elements/') ? 'elements' : 'css';
+  const patchFile = commitFile.substring(`ed/${patchType}/`.length);
+  console.log('  done');
+
+  console.log('Retrieve commit title...');
+  const { stdout: titleOut } = await execFile('git', ['log', '-1', '--pretty=%s']);
+  const patchTitle = titleOut.trim();
+  console.log(`  found "${patchTitle}"`);
+
+  console.log('Create patch file from last commit...');
+  const { stdout: patchOut } = await execFile('git', ['format-patch', '-1']);
+  const rawPatchFile = patchOut.trim();
+  console.log('  done');
+
+  console.log('Rollback last commit...');
+  await execFile('git', ['reset', 'HEAD~']);
+  await execFile('git', ['restore', commitFile]);
+  console.log('  done');
+
+  console.log('Move patch file to appropriate patch folder...');
+  const finalPatchFile = path.join('ed', patchType + 'patches', patchFile + '.patch');
+  await execFile('mv', [rawPatchFile, finalPatchFile]);
+  console.log(`  moved to ${finalPatchFile}`);
+
+  console.log('Commit patch file to a separate branch...');
+  const branchName = 'patch-' + (new Date()).toISOString().replace(/[^\d]/g, '');
+  await execFile('git', ['co', '-b', branchName]);
+  await execFile('git', ['add', finalPatchFile]);
+  await execFile('git', ['commit', '-m', `Add patch for ${commitFile}`, '-m', patchTitle]);
+  console.log(`  committed to branch ${branchName}`);
+
+  console.log();
+  console.log('Next steps:');
+  console.log(`1. Make sure that ${finalPatchFile} looks good`);
+  console.log(`2. Push branch to GitHub: git push origin ${branchName}`);
+  console.log(`3. Go to https://github.com/w3c/webref and create a pull request`);
+  console.log(`4. Once happy, switch back to default branch locally and delete branch ${branchName}`);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
This adds a quick and dirty create-patch tool to help with the creation of patches. Tool can be called through one of:

```
node tools/create-patch.js
npm run create-patch
```

The tool takes for granted that last commit to current branch was to update one CSS/elements/IDL extract file. It creates a patch file out of it, rolls back that commit, copies the patch file to ed/csspatches or ed/idlpatches as needed, and commits the file in a new branch.

Manual tasks that remain on top of preparing the initial commit are to review the created patch, push it to GitHub, create the PR and get back to the appropriate branch locally.

FYI, I've been using that little tool to create the last couple of patches.