### PR TITLE
Enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+    time: '10:00'
+  open-pull-requests-limit: 10


### PR DESCRIPTION
Some of the dependencies versions are getting outdated and we need to use the
latest version of WebIDL2.js to run Web IDL validation tests, otherwise we'll
miss recent updates made to the Web IDL spec.