### PR TITLE
Fix IDL patch for Web Animations Level 2

### DIFF
--- a/ed/idlpatches/web-animations-2.idl.patch
+++ b/ed/idlpatches/web-animations-2.idl.patch
@@ -17,7 +17,7 @@ index 1b5db8b13..2bc7aa412 100644
 --- a/ed/idl/web-animations-2.idl
 +++ b/ed/idl/web-animations-2.idl
 @@ -38,8 +38,6 @@ partial dictionary ComputedEffectTiming {
-     CSSNumberish?        progress;
+     CSSNumberish?        localTime;
  };
  
 -enum FillMode { "none", "forwards", "backwards", "both", "auto" };


### PR DESCRIPTION
The `progress` property in `ComputedEffectTiming`, on which the patch was anchored, was dropped a couple of days ago, requiring to update the anchor.

Patch unchanged otherwise.

(CI tests will fail because of a duplicate IDL attribute issue for `onvisibilitychange` on `Document` that [should soon be addressed](https://github.com/w3c/page-visibility/pull/73))