### PR TITLE
Restore ComputedEffectTiming.progress

### DIFF
--- a/ed/idlpatches/web-animations.idl.patch
+++ b/ed/idlpatches/web-animations.idl.patch
@@ -31,7 +31,7 @@ index 6e973d195..2b5f672b9 100644
      PlaybackDirection                  direction = "normal";
      DOMString                          easing = "linear";
  };
-@@ -86,9 +83,6 @@ enum FillMode { "none", "forwards", "backwards", "both", "auto" };
+@@ -86,10 +83,7 @@ enum FillMode { "none", "forwards", "backwards", "both", "auto" };
  enum PlaybackDirection { "normal", "reverse", "alternate", "alternate-reverse" };
  
  dictionary ComputedEffectTiming : EffectTiming {


### PR DESCRIPTION
It's [removed from level 2 spec](https://github.com/w3c/csswg-drafts/pull/6712) and thus should be restored.