### PR TITLE
Update @webref/idl@latest and css@latest branches when publishing tagged releases

### DIFF
--- a/tools/release-package.js
+++ b/tools/release-package.js
@@ -95,6 +95,12 @@ async function releasePackage(prNumber) {
         sha: preReleaseSha
       });
       console.log(`- Tagged released commit ${preReleaseSha} with tag ${tag}`);
+      await octokit.git.updateRef({
+        owner, repo,
+        ref: `@webref/${type}@latest`,
+        sha: preReleaseSha
+      });
+      console.log(`- Updated ${type}-latest to point to released commit ${preReleaseSha}`);
     }
   }
   finally {


### PR DESCRIPTION
This makes it easier to always checkout the latest curated version of the repo. I'm planning to use it to help with maintaining MDN data.

I've already created the relevant branches on the repo.