### PR TITLE
Fix name of reference for setting @latest branch

### DIFF
--- a/tools/release-package.js
+++ b/tools/release-package.js
@@ -97,7 +97,7 @@ async function releasePackage(prNumber) {
       console.log(`- Tagged released commit ${preReleaseSha} with tag ${tag}`);
       await octokit.git.updateRef({
         owner, repo,
-        ref: `refs/head/@webref/${type}@latest`,
+        ref: `refs/heads/@webref/${type}@latest`,
         sha: preReleaseSha
       });
       console.log(`- Updated ${type}-latest to point to released commit ${preReleaseSha}`);


### PR DESCRIPTION
as noted in https://github.com/w3c/webref/pull/439#issuecomment-995551274

crossing fingers… I've manually set the @latest branches in the meantime.