### PR TITLE
Fix release of @latest tags

### DIFF
--- a/tools/release-package.js
+++ b/tools/release-package.js
@@ -97,7 +97,7 @@ async function releasePackage(prNumber) {
       console.log(`- Tagged released commit ${preReleaseSha} with tag ${tag}`);
       await octokit.git.updateRef({
         owner, repo,
-        ref: `refs/heads/@webref/${type}@latest`,
+        ref: `heads/@webref/${type}@latest`,
         sha: preReleaseSha
       });
       console.log(`- Updated ${type}-latest to point to released commit ${preReleaseSha}`);


### PR DESCRIPTION
Refs passed to updateRef should not be prefixed with refs per https://github.com/octokit/octokit.net/blob/8cd893d6d4a7f062871caed7a555511d45579bdc/Octokit/Clients/ReferencesClient.cs#L274