### PR TITLE
Add IDL patch for Autoplay Policy Detection

### DIFF
--- a/ed/idlpatches/autoplay.idl.patch
+++ b/ed/idlpatches/autoplay.idl.patch
@@ -1,0 +1,46 @@
+From 6ffaa3810c23b9ee77d3279fc8f89058f3f6a7bc Mon Sep 17 00:00:00 2001
+From: Francois Daoust <fd@tidoust.net>
+Date: Mon, 17 Jan 2022 15:33:55 +0100
+Subject: [PATCH] Revert to previous API design pending IDL fixes
+
+Some design issues with the new API:
+
+https://github.com/w3c/autoplay/pull/20
+https://github.com/w3c/autoplay/issues/21
+---
+ ed/idl/autoplay.idl | 19 +++++--------------
+ 1 file changed, 5 insertions(+), 14 deletions(-)
+
+diff --git a/ed/idl/autoplay.idl b/ed/idl/autoplay.idl
+index 2fa30ca0e..b00295d94 100644
+--- a/ed/idl/autoplay.idl
++++ b/ed/idl/autoplay.idl
+@@ -9,19 +9,10 @@ enum AutoplayPolicy {
+   "disallowed"
+ };
+ 
+-callback HTMLMediaElementConstructor = HTMLMediaElement ();
+-callback AudioContextConstructor = AudioContext ();
+-
+-[Exposed=Window]
+-partial interface Navigator {
+-  AutoplayPolicy getAutoplayPolicy(HTMLMediaElementConstructor ctor);
+-
+-  AutoplayPolicy getAutoplayPolicy(AudioContextConstructor ctor);
++partial interface Document {
++  readonly attribute AutoplayPolicy autoplayPolicy;
+ };
+ 
+-[Exposed=Window]
+-partial interface Navigator {
+-  AutoplayPolicy getAutoplayPolicy(HTMLMediaElement element);
+-
+-  AutoplayPolicy getAutoplayPolicy(AudioContext context);
+-};
++partial interface HTMLMediaElement {
++  readonly attribute AutoplayPolicy autoplayPolicy;
++};
+\ No newline at end of file
+-- 
+2.34.1.windows.1
+


### PR DESCRIPTION
The patch rolls back the IDL to what it was previously, pending resolution of design issues with the new IDL.