### PR TITLE
Curation job: retrieve all history when checking out repo

### DIFF
--- a/.github/workflows/curate.yml
+++ b/.github/workflows/curate.yml
@@ -30,6 +30,10 @@ jobs:
 
     - name: Checkout webref
       uses: actions/checkout@v2
+      with:
+        # Need to checkout all history as curation job also needs to access
+        # the curated branch
+        fetch-depth: 0
 
     - name: Prepare curated and packages data
       # Note that "ci" runs the "prepare" script


### PR DESCRIPTION
The checkout action only gets a single commit by default, but the job also needs to access and the curated branch.