### PR TITLE
Do not include diff of index.js in pre-release PR

### DIFF
--- a/tools/prepare-release.js
+++ b/tools/prepare-release.js
@@ -70,7 +70,7 @@ function computeDiff(type) {
   // code to 0 to avoid the exception.
   const installedFiles = path.join(tmpFolder, "node_modules", "@webref", type);
   let diff = execSync(
-    `diff ${installedFiles} packages/${type} --ignore-trailing-space --exclude=package.json --unified=3 || echo -n`,
+    `diff ${installedFiles} packages/${type} --ignore-trailing-space --exclude=package.json --exclude=README.md --exclude=index.js --unified=3 || echo -n`,
     { encoding: "utf8" });
 
   // Diff includes added/removed files but they are hard to detect inline,
@@ -120,7 +120,7 @@ function computeDiff(type) {
 
   if (added.length > 0) {
     diff = "New repo files that are not yet in the released package:\n" +
-      added.map(file => `- ${file}`).join("\n") +
+      added.map(file => `+ ${file}`).join("\n") +
       "\n\n" +
       diff;
   }


### PR DESCRIPTION
Presumably we use the diff to focus on data review, not general package review