### PR TITLE
Remove non-browser specs from curated IDL names and npm packages

### DIFF
--- a/tools/prepare-curated.js
+++ b/tools/prepare-curated.js
@@ -130,7 +130,7 @@ async function prepareCurated(rawFolder, curatedFolder) {
   console.log();
   console.log('Re-generate the idlnames and idlnamesparsed folders');
   crawlResults = await expandCrawlResult(crawlIndex, curatedFolder, ['idlparsed', 'dfns']);
-  console.log('- TODO: only keep browser specs (when we can distinguish them)');
+  crawlResults.results = crawlResults.results.filter(spec => spec.categories?.includes('browser'));
   const idlNames = generateIdlNames(crawlResults.results, { dfns: true });
   await saveIdlNames(idlNames, curatedFolder);
   console.log('- done');

--- a/tools/prepare-packages.js
+++ b/tools/prepare-packages.js
@@ -45,8 +45,9 @@ async function preparePackages(curatedFolder, packagesFolder) {
     console.log(`- cleaned ${dstDir} folder`);
 
     // Only keep specs targeted at browsers
-    const specs = crawlIndex.results.filter(spec => spec[name]);
-    console.log('- TODO: only keep specs targeted at browsers');
+    const specs = crawlIndex.results
+      .filter(spec => spec[name])
+      .filter(spec => spec.categories?.includes('browser'));
     console.log(`- ${specs.length}/${crawlIndex.results.length} specs to include in the package`);
 
     // cp ${curatedFolder}/${name}/*.${fileExt} packages/${name}


### PR DESCRIPTION
This update replaces the TODOs that had been envisioned with actual spec filtering to remove specs that don't target web browsers when creating the curated view of the `idlnames` and `idlnamesparsed` folder. These specs are also removed from the `@webref/xxx` npm packages.