### PR TITLE
Patch invalid WebIDL in HTML for CanvasPath.roundRect

### DIFF
--- a/ed/idlpatches/html.idl.patch
+++ b/ed/idlpatches/html.idl.patch
@@ -1,0 +1,26 @@
+From 5753fa36cb3e51ea5896c767f468b3a8ec821444 Mon Sep 17 00:00:00 2001
+From: Dominique Hazael-Massieux <dom@w3.org>
+Date: Thu, 24 Feb 2022 08:27:25 +0100
+Subject: [PATCH] Fix IDL for CanvasPath.roundRect
+
+Following expected resolution of https://github.com/whatwg/html/issues/7634
+---
+ ed/idl/html.idl | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ed/idl/html.idl b/ed/idl/html.idl
+index db4495ef9..b844dcc32 100644
+--- a/ed/idl/html.idl
++++ b/ed/idl/html.idl
+@@ -1480,7 +1480,7 @@ interface mixin CanvasPath {
+   undefined bezierCurveTo(unrestricted double cp1x, unrestricted double cp1y, unrestricted double cp2x, unrestricted double cp2y, unrestricted double x, unrestricted double y);
+   undefined arcTo(unrestricted double x1, unrestricted double y1, unrestricted double x2, unrestricted double y2, unrestricted double radius);
+   undefined rect(unrestricted double x, unrestricted double y, unrestricted double w, unrestricted double h);
+-  undefined roundRect(unrestricted double x, unrestricted double y, unrestricted double w, unrestricted double h, (unrestricted double or DOMPointInit or sequence<(unrestricted double or DOMPointInit)>) radii);
++  undefined roundRect(unrestricted double x, unrestricted double y, unrestricted double w, unrestricted double h, optional (unrestricted double or DOMPointInit or sequence<(unrestricted double or DOMPointInit)>) radii = {});
+   undefined arc(unrestricted double x, unrestricted double y, unrestricted double radius, unrestricted double startAngle, unrestricted double endAngle, optional boolean counterclockwise = false);
+   undefined ellipse(unrestricted double x, unrestricted double y, unrestricted double radiusX, unrestricted double radiusY, unrestricted double rotation, unrestricted double startAngle, unrestricted double endAngle, optional boolean counterclockwise = false);
+ };
+-- 
+2.35.1
+


### PR DESCRIPTION
see also https://github.com/w3c/webref/pull/506#issuecomment-1046557530 and https://github.com/whatwg/html/issues/7634