### PR TITLE
[Tests] Add parsing exception for "cursor" CSS property

### DIFF
--- a/test/css/all.js
+++ b/test/css/all.js
@@ -26,10 +26,19 @@ const cssValues = [
 // See: https://github.com/w3c/reffy/issues/494#issuecomment-790713119
 // (last validated on 2022-04-07)
 const tempIgnore = [
+  // Stacked combinator "+#?" not supported by css-tree
   { shortname: 'css-extensions', prop: 'valuespaces', name: '<custom-selector>' },
+
+  // Stacked combinator "#?" not supported by css-tree
   { shortname: 'css-ui', prop: 'properties', name: 'cursor' },
+
+  // Stacked combinator "+#" not supported by css-tree
   { shortname: 'fill-stroke', prop: 'properties', name: 'stroke-dasharray' },
+
+  // Unescaped comma with multiplier ",*" not supported by css-tree
   { shortname: 'svg-animations', prop: 'valuespaces', name: '<control-point>' },
+
+  // Stacked combinator "#*" not supported by css-tree
   { shortname: 'svg-strokes', prop: 'valuespaces', name: '<dasharray>' }
 ];
 

--- a/test/css/all.js
+++ b/test/css/all.js
@@ -24,9 +24,10 @@ const cssValues = [
 
 // TEMP: constructs that are not yet supported by the parser
 // See: https://github.com/w3c/reffy/issues/494#issuecomment-790713119
-// (last validated on 2021-12-17)
+// (last validated on 2022-04-07)
 const tempIgnore = [
   { shortname: 'css-extensions', prop: 'valuespaces', name: '<custom-selector>' },
+  { shortname: 'css-ui', prop: 'properties', name: 'cursor' },
   { shortname: 'fill-stroke', prop: 'properties', name: 'stroke-dasharray' },
   { shortname: 'svg-animations', prop: 'valuespaces', name: '<control-point>' },
   { shortname: 'svg-strokes', prop: 'valuespaces', name: '<dasharray>' }


### PR DESCRIPTION
The `cursor` property definition now uses a stack combinator `#?`, which is not supported by the `css-tree` parser. Adding the property to the list of exceptions as a result.