### PR TITLE
Drop duplicate CSS property definitions when curating data

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Data curation brings the following guarantees.
 ### CSS extracts
 
 - All CSS files can be parsed by the version of [CSSTree](https://github.com/csstree/csstree) referenced in `package.json`, with the exception of a handful CSS value definitions that, although valid, are not yet supported by CSSTree.
+- No duplicate definitions of CSS properties provided that CSS extracts of [delta specs](https://github.com/w3c/browser-specs/#seriescomposition) are not taken into account (such extracts end with `-n.json`, where `n` is a level number).
+- CSS extracts contain a base definition of all CSS properties that get extended by other CSS property definitions (those for which `newValues` is set).
 
 ### Elements extracts
 

--- a/packages/css/README.md
+++ b/packages/css/README.md
@@ -41,3 +41,5 @@ for (const [shortname, data] of Object.entries(parsedFiles)) {
 
 The following guarantees are provided by this package:
 - All CSS files can be parsed by the version of [CSSTree](https://github.com/csstree/csstree) used in `peerDependencies` in `package.json`, with the exception of a handful CSS value definitions that, although valid, are not yet supported by CSSTree.
+- No duplicate definitions of CSS properties provided that CSS extracts of [delta specs](https://github.com/w3c/browser-specs/#seriescomposition) are not taken into account (such extracts end with `-n.json`, where `n` is a level number).
+- CSS extracts contain a base definition of all CSS properties that get extended by other CSS property definitions (those for which `newValues` is set).

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@webref/css",
   "description": "CSS definitions of the web platform",
-  "version": "3.1.1",
+  "version": "4.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/w3c/webref.git"

--- a/tools/bump-packages-minor.js
+++ b/tools/bump-packages-minor.js
@@ -15,13 +15,13 @@
 
 const fs = require('fs').promises;
 const path = require('path');
-const { requireFromWorkingDirectory } = require('./utils');
+const { loadJSON } = require('./utils');
 const { execSync } = require('child_process');
 
 async function checkPackage(type) {
   console.log(`Check ${type} package`);
   const packageFile = path.resolve(__dirname, '..', 'packages', type, 'package.json');
-  const package = requireFromWorkingDirectory(packageFile);
+  const package = await loadJSON(packageFile);
   const version = package.version;
   console.log(`- Current version: ${version}`);
 

--- a/tools/clean-dropped-specs-files.js
+++ b/tools/clean-dropped-specs-files.js
@@ -19,7 +19,7 @@
 
 const fs = require("fs").promises;
 const path = require("path");
-const { requireFromWorkingDirectory } = require('./utils');
+const { loadJSON } = require('./utils');
 
 const idlnamesSubdirs = ['idlnames', 'idlnamesparsed'];
 
@@ -40,7 +40,7 @@ async function cleanExtractFolder(folder, crawlResults) {
 
 async function cleanCrawlFolder(crawlFolder) {
   console.log('Load crawl results');
-  const indexFile = requireFromWorkingDirectory(path.join(crawlFolder, 'index.json'));
+  const indexFile = await loadJSON(path.join(crawlFolder, 'index.json'));
   const crawlResults = indexFile.results;
   if (!crawlResults) {
     throw new Error('The index.json file does not seem to contain crawl results');

--- a/tools/drop-css-property-duplicates.js
+++ b/tools/drop-css-property-duplicates.js
@@ -1,0 +1,162 @@
+/**
+ * Drop CSS property definition duplicates for situations where definition in
+ * one spec is known to override the same definition in another spec.
+ *
+ *
+ * node tools/drop-css-property-duplicates.js [folder]
+ * 
+ * ... where:
+ * - [folder] is the name of the folder that contains the data to parse
+ * and update (default is "curated")
+ */
+
+const fs = require('fs').promises;
+const path = require('path');
+const util = require('util');
+const execFile = util.promisify(require('child_process').execFile);
+const requireFromWorkingDirectory = require('./utils').requireFromWorkingDirectory;
+const expandCrawlResult = require('reffy').expandCrawlResult;
+
+
+/**
+ * Known superseding relationships between CSS/SVG specs
+ */
+const supersededBy = {
+  // All CSS modules supersede CSS 2.x
+  'CSS': '*',
+
+  // See note in https://drafts.csswg.org/css-align/#placement
+  // "The property definitions here supersede those in [CSS-FLEXBOX-1]"
+  'css-flexbox': 'css-align',
+
+  // https://github.com/w3c/csswg-drafts/issues/6434#issuecomment-877447360
+  'css-logical': 'css-position',
+
+  // See https://github.com/w3c/csswg-drafts/issues/6435
+  // (string-set property defined twice)
+  'css-gcpm': 'css-content',
+
+  // See https://github.com/w3c/csswg-drafts/issues/6433
+  // (shape-inside should get dropped from css-round-display)
+  'css-round-display': 'css-shapes',
+
+  // See note in https://svgwg.org/specs/strokes/#sotd
+  // "In the future, this specification will supersede the SVG 2 Stroke
+  // definition, however at this time the SVG 2 Stroke definition must be
+  // considered the normative definition."
+  'svg-strokes': 'SVG',
+
+  // TODO: confirm that CSS modules supersede SVG 2
+  'SVG': [
+    'css-images',   // image-rendering
+    'css-logical',  // inline-size
+    'css-shapes',   // shape-inside, shape-margin
+    'css-ui',       // pointer-events
+    'fill-stroke'   // all properties in fill-stroke
+  ]
+};
+
+
+async function dropCSSPropertyDuplicates(folder) {
+  const rawIndex = requireFromWorkingDirectory(path.join(folder, 'index.json'));
+  const index = await expandCrawlResult(rawIndex, folder, ['css']);
+  
+  const properties = {};
+  for (const spec of index.results) {
+    if (!spec.css?.properties) {
+      continue;
+    }
+    for (const [name, dfn] of Object.entries(spec.css.properties)) {
+      if (dfn.newValues) {
+        // Extension of a base definition, does not count as duplicate
+        continue;
+      }
+      if (!properties[name]) {
+        properties[name] = [];
+      }
+      properties[name].push(spec);
+    }
+  }
+
+  let duplicates = 0;
+  for (const [name, specs] of Object.entries(properties)) {
+    if (specs.length > 1) {
+      properties[name] = specs.filter(spec => {
+        const shortname = spec.series.shortname;
+        if ((spec.seriesComposition === 'delta') &&
+            specs.find(s => s !== spec && s.series.shortname === shortname)) {
+          // Property name both defined in delta spec and in base full spec,
+          // let's ignore the duplication.
+          return false;
+        }
+
+        const superseding = [supersededBy[shortname]].flat();
+        if (superseding[0] === '*' ||
+            specs.find(s => superseding.includes(s.series.shortname))) {
+          // Property name defined in a spec that supersedes the current one,
+          // drop the property definition from the current spec
+          delete spec.css.properties[name];
+          spec.needsSaving = true;
+          return false;
+        }
+        return true;
+      });
+    }
+    if (properties[name].length > 1) {
+      console.error(`- ${name} defined in ${properties[name].map(spec => `[${spec.shortTitle}](${spec.url})`).join(', ')}`);
+      duplicates += 1;
+    }
+  }
+
+  function getBaseJSON(spec) {
+    return {
+      spec: {
+        title: spec.title,
+        url: spec.crawled
+      }
+    };
+  }
+
+  async function saveCss(spec) {
+    // There are no comments in JSON, so include the spec title+URL as the
+    // first property instead.
+    const css = Object.assign({
+      spec: {
+        title: spec.title,
+        url: spec.crawled
+      }
+    }, spec.css);
+    const json = JSON.stringify(css, null, 2) + '\n';
+    const pathname = path.join(folder, 'css', spec.series.shortname + '.json')
+    await fs.writeFile(pathname, json);
+  };
+
+  for (const spec of index.results) {
+    if (spec.needsSaving) {
+      await saveCss(spec);
+    }
+  }
+
+  if (duplicates) {
+    throw new Error('Duplicate CSS properties found, see log for details');
+  }
+}
+
+
+/**************************************************
+Export methods for use as module
+**************************************************/
+module.exports.dropCSSPropertyDuplicates = dropCSSPropertyDuplicates;
+
+
+/**************************************************
+Code run if the code is run as a stand-alone module
+**************************************************/
+if (require.main === module) {
+  const folder = process.argv[2] ?? 'curated';
+  
+  dropCSSPropertyDuplicates(folder).catch(e => {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/tools/drop-css-property-duplicates.js
+++ b/tools/drop-css-property-duplicates.js
@@ -14,7 +14,7 @@ const fs = require('fs').promises;
 const path = require('path');
 const util = require('util');
 const execFile = util.promisify(require('child_process').execFile);
-const requireFromWorkingDirectory = require('./utils').requireFromWorkingDirectory;
+const loadJSON = require('./utils').loadJSON;
 const expandCrawlResult = require('reffy').expandCrawlResult;
 
 
@@ -58,7 +58,7 @@ const supersededBy = {
 
 
 async function dropCSSPropertyDuplicates(folder) {
-  const rawIndex = requireFromWorkingDirectory(path.join(folder, 'index.json'));
+  const rawIndex = await loadJSON(path.join(folder, 'index.json'));
   const index = await expandCrawlResult(rawIndex, folder, ['css']);
   
   const properties = {};

--- a/tools/prepare-curated.js
+++ b/tools/prepare-curated.js
@@ -21,7 +21,7 @@ const {
   generateIdlParsed, saveIdlParsed } = require('reffy');
 const {
   createFolderIfNeeded,
-  requireFromWorkingDirectory,
+  loadJSON,
   copyFolder } = require('./utils');
 const { applyPatches } = require('./apply-patches');
 const { dropCSSPropertyDuplicates } = require('./drop-css-property-duplicates');
@@ -97,7 +97,7 @@ async function prepareCurated(rawFolder, curatedFolder) {
   console.log('- patches applied');
 
   let crawlIndexFile = path.join(curatedFolder, 'index.json');
-  let crawlIndex = requireFromWorkingDirectory(crawlIndexFile);
+  let crawlIndex = await loadJSON(crawlIndexFile);
   await Promise.all(crawlIndex.results.map(cleanCrawlOutcome));
   await fs.writeFile(crawlIndexFile, JSON.stringify(crawlIndex, null, 2));
   console.log('- crawl outcome adjusted');

--- a/tools/prepare-curated.js
+++ b/tools/prepare-curated.js
@@ -23,7 +23,8 @@ const {
   createFolderIfNeeded,
   requireFromWorkingDirectory,
   copyFolder } = require('./utils');
-const { applyPatches } = require('./apply-patches.js');
+const { applyPatches } = require('./apply-patches');
+const { dropCSSPropertyDuplicates } = require('./drop-css-property-duplicates');
 
 
 /**
@@ -100,6 +101,11 @@ async function prepareCurated(rawFolder, curatedFolder) {
   await Promise.all(crawlIndex.results.map(cleanCrawlOutcome));
   await fs.writeFile(crawlIndexFile, JSON.stringify(crawlIndex, null, 2));
   console.log('- crawl outcome adjusted');
+
+  console.log();
+  console.log('Drop duplicate CSS property definitions when possible');
+  await dropCSSPropertyDuplicates(curatedFolder);
+  console.log('- done');
 
   console.log();
   console.log('Re-generate the idlparsed folder');

--- a/tools/prepare-packages.js
+++ b/tools/prepare-packages.js
@@ -17,11 +17,11 @@ const fs = require('fs').promises;
 const path = require('path');
 const util = require('util');
 const execFile = util.promisify(require('child_process').execFile);
-const { requireFromWorkingDirectory } = require('./utils');
+const { loadJSON } = require('./utils');
 
 async function preparePackages(curatedFolder, packagesFolder) {
   console.log('Load crawl index file');
-  const crawlIndex = requireFromWorkingDirectory(path.join(curatedFolder, 'index.json'));
+  const crawlIndex = await loadJSON(path.join(curatedFolder, 'index.json'));
   console.log(`- ${crawlIndex.results.length} curated specs in index file`);
 
   const packages = [

--- a/tools/utils.js
+++ b/tools/utils.js
@@ -18,21 +18,17 @@ async function createFolderIfNeeded(folder) {
 
 
 /**
- * Wrapper around the "require" function to require files relative to the
- * current working directory (CWD), instead of relative to the current JS
- * file.
- *
- * This is typically needed to be able to use "require" to load JSON config
- * files provided as command-line arguments.
+ * Load a JSON file as JS object.
  *
  * @function
  * @param {String} filename The path to the file to require
- * @return {Object} The result of requiring the file relative to the current
- *   working directory.
+ * @return {Object} The result of loading and parsing the file relative to the
+ *   current working directory.
  */
-function requireFromWorkingDirectory(filename) {
+async function loadJSON(filename) {
   try {
-    return require(path.resolve(filename));
+    const json = await fs.readFile(filename, 'utf8');
+    return JSON.parse(json);
   }
   catch (err) {
     return null;
@@ -73,6 +69,6 @@ async function copyFolder(source, target, { excludeRoot = false } = {}) {
 
 module.exports = {
   createFolderIfNeeded,
-  requireFromWorkingDirectory,
+  loadJSON,
   copyFolder
 };


### PR DESCRIPTION
This adds a new data curation step that drops duplicate CSS property definitions from CSS extracts whenever possible, in other words when we know which definition is the authoritative one. The code contains a list of known superseding relationships between specs to choose the right one. See discussion in https://github.com/w3c/webref/issues/127 for details.

CSS properties that get re-defined in a delta spec are ignored, meaning that a naive merge of all curated CSS extracts will still contain such duplicates. A typical solution to end up with a consistent merge would be to exclude delta specs from that merge. This is left to data consumers as some may choose to rather live on the bleeding edge.

The curated data may still contain duplicate CSS property definitions, but these will get caught by tests. The new tests also check that CSS extracts contain a base CSS property definition for all CSS properties that get extended (through `newValues`).