### PR TITLE
Cleanup job: create PR without a "draft" status

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -25,6 +25,5 @@ jobs:
         body: |
           This removes previously extracted files that are no longer referenced in browser-specs
         assignees: tidoust, dontcallmedom
-        draft: true
         branch: cleanup
         branch-suffix: timestamp


### PR DESCRIPTION
A PR created as "draft" requires an extra manual step since it cannot be merged directly.