### PR TITLE
Add patch for ed/css/css-color.json

### DIFF
--- a/ed/csspatches/css-color.json.patch
+++ b/ed/csspatches/css-color.json.patch
@@ -1,0 +1,44 @@
+From 7b815910e42fc0c102bc712a08808ec780b4aa59 Mon Sep 17 00:00:00 2001
+From: Francois Daoust <fd@tidoust.net>
+Date: Mon, 25 Apr 2022 11:50:02 +0200
+Subject: [PATCH] Add legacy values for rgb() and hsl() definitions
+
+The legacy values cannot easily be extracted from the prose (and if they were,
+we would have a hard time qualifying them as legacy definitions). Tools that
+want to handle legacy values need to join the `value` property and the
+`legacyValue` with a `|`.
+
+Definitions are at:
+https://drafts.csswg.org/css-color-4/#ref-for-legacy-color-syntax%E2%91%A1
+https://drafts.csswg.org/css-color-4/#ref-for-legacy-color-syntax%E2%91%A3
+
+Via https://github.com/w3c/webref/issues/563
+---
+ ed/css/css-color.json | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/ed/css/css-color.json b/ed/css/css-color.json
+index 67e5e088a..dcb76a326 100644
+--- a/ed/css/css-color.json
++++ b/ed/css/css-color.json
+@@ -45,13 +45,15 @@
+       "value": "<number> | <angle> | none"
+     },
+     "<rgb()>": {
+-      "value": "rgb( [<percentage> | none]{3} [ / [<alpha-value> | none] ]? ) | rgb( [<number> | none]{3} [ / [<alpha-value> | none] ]? )"
++      "value": "rgb( [<percentage> | none]{3} [ / [<alpha-value> | none] ]? ) | rgb( [<number> | none]{3} [ / [<alpha-value> | none] ]? )",
++      "legacyValue": "rgb( <percentage>#{3} , <alpha-value>? ) | rgb( <number>#{3} , <alpha-value>? )"
+     },
+     "<alpha-value>": {
+       "value": "<number> | <percentage>"
+     },
+     "<hsl()>": {
+-      "value": "hsl( [<hue> | none] [<percentage> | none] [<percentage> | none] [ / [<alpha-value> | none] ]? )"
++      "value": "hsl( [<hue> | none] [<percentage> | none] [<percentage> | none] [ / [<alpha-value> | none] ]? )",
++      "legacyValue": "hsl( <hue>, <percentage>, <percentage>, <alpha-value>? )"
+     },
+     "<hwb()>": {
+       "value": "hwb( [<hue> | none] [<percentage> | none] [<percentage> | none] [ / [<alpha-value> | none] ]? )"
+-- 
+2.36.0.windows.1
+


### PR DESCRIPTION
This adds legacy values for the `<rgb()>` and `<hsl()>` definitions.

The legacy values cannot easily be extracted from the prose (and if they could, we would have a hard time qualifying them as legacy definitions). Tools that want to handle legacy values need to join the `value` property and the `legacyValue` with a `|`.

Definitions are at:
https://drafts.csswg.org/css-color-4/#ref-for-legacy-color-syntax%E2%91%A1
https://drafts.csswg.org/css-color-4/#ref-for-legacy-color-syntax%E2%91%A3

This would fix https://github.com/w3c/webref/issues/563

Existential bump question: At a minimum, this should trigger a minor bump for `@webref/css`. Should this trigger a major bump? The new property adds new info but does not require changes in the way data consumers need to handle the data (unless they want to leverage the new info of course), so perhaps that's not needed?