### PR TITLE
CSS color patch: drop link to patch issue

### DIFF
--- a/ed/csspatches/css-color.json.patch
+++ b/ed/csspatches/css-color.json.patch
@@ -13,8 +13,6 @@ https://drafts.csswg.org/css-color-4/#ref-for-legacy-color-syntax%E2%91%A3
 
 Tools that want to handle legacy values need to join the `value` property and
 the `legacyValue` with a `|`.
-
-Via https://github.com/w3c/webref/issues/563
 ---
  ed/css/css-color.json | 6 ++++--
  1 file changed, 4 insertions(+), 2 deletions(-)


### PR DESCRIPTION
The issue was for creating the patch, but the "Clean patches" job gets confused and assumes that it is the tracking issue for deleting the patch, see:
https://github.com/w3c/webref/pull/576