### PR TITLE
Add patch for ed/elements/html.json

### DIFF
--- a/ed/elementspatches/html.json.patch
+++ b/ed/elementspatches/html.json.patch
@@ -1,6 +1,6 @@
-From cb31d9b6e0d8063d745687b268fe153ce5d21191 Mon Sep 17 00:00:00 2001
+From 8281cf7530d27497d3577ec01fc156b4ec898359 Mon Sep 17 00:00:00 2001
 From: Francois Daoust <fd@tidoust.net>
-Date: Fri, 22 Apr 2022 15:39:27 +0200
+Date: Fri, 29 Apr 2022 09:48:23 +0200
 Subject: [PATCH] Add obsolete HTML elements
 
 Patches the list of HTML elements with elements that are entirely obsolete but
@@ -24,7 +24,7 @@ both cases).
  1 file changed, 145 insertions(+)
 
 diff --git a/ed/elements/html.json b/ed/elements/html.json
-index 4754a89db..d1cd88d99 100644
+index 4754a89db..70cb4557c 100644
 --- a/ed/elements/html.json
 +++ b/ed/elements/html.json
 @@ -447,6 +447,151 @@
@@ -181,5 +181,5 @@ index 4754a89db..d1cd88d99 100644
  }
 \ No newline at end of file
 -- 
-2.35.1.windows.2
+2.36.0.windows.1
 


### PR DESCRIPTION
Patch had been updated manually following removal of the `<param>` element, but that manual update did not work (and was missed because other tests are currently failing). This re-generates the patch.