### PR TITLE
Allow static and regular operations with same name

### DIFF
--- a/test/idl/consistency.js
+++ b/test/idl/consistency.js
@@ -64,6 +64,28 @@ function isOverloadedOperation(a, b) {
   return true;
 }
 
+// Helper to test if two members define an operation with the same identifier,
+// one of them being a static operation and the other a regular one. This is
+// allowed in Web IDL, see https://github.com/whatwg/webidl/issues/1097
+function isAllowedOperationWithSameIdentifier(a, b) {
+  if (a.type !== 'operation') {
+    return false;
+  }
+  if (a.type !== b.type) {
+    return false;
+  }
+  if (a.name !== b.name) {
+    return false;
+  }
+  if (a.special !== 'static' && b.special !== 'static') {
+    return false;
+  }
+  if (a.special === b.special) {
+    return false;
+  }
+  return true;
+}
+
 function describeDfn(dfn) {
   let desc = dfn.type;
   if (dfn.name) {
@@ -159,6 +181,10 @@ function merge(dfns, partials, includes) {
         // Non-overlapping exposure sets are OK. Assume it's OK if either
         // members has an [Exposed] extended attribute. TODO: do better.
         if (getExtAttr(firstMember, 'Exposed') || getExtAttr(member, 'Exposed')) {
+          continue;
+        }
+        // A static operation that has the same identifier as a regular one is OK
+        if (isAllowedOperationWithSameIdentifier(member, firstMember)) {
           continue;
         }
         assert.fail(`duplicate definition of ${dfn.name} member ${member.name}`);


### PR DESCRIPTION
See https://github.com/whatwg/webidl/issues/1097 for context.

This update adds a final check before reporting duplicated members to make sure that the members are not a static and a regular operation with the same identifier (now allowed in Web IDL).

This is needed to account for the recent IDL update in the Fetch API:
https://github.com/whatwg/fetch/commit/b3bfd0c877fd09da8c315b43cf1dd858f3ac1612

Note that CI tests will continue to fail for now because such IDL constructs currently also get reported as invalid by webidl2.js when the operations are defined across partials or mixins, see https://github.com/w3c/webidl2.js/issues/672