### PR TITLE
Adjust duplicate CSS handling rules and tests

### DIFF
--- a/test/css/all.js
+++ b/test/css/all.js
@@ -37,51 +37,21 @@ const tempIgnore = [
   { shortname: 'fill-stroke', prop: 'properties', name: 'stroke-dasharray' },
 
   // Unescaped comma with multiplier ",*" not supported by css-tree
-  { shortname: 'svg-animations', prop: 'valuespaces', name: '<control-point>' },
-
-  // Stacked combinator "#*" not supported by css-tree
-  { shortname: 'svg-strokes', prop: 'valuespaces', name: '<dasharray>' }
+  { shortname: 'svg-animations', prop: 'valuespaces', name: '<control-point>' }
 ];
 
 
 // Valuespaces that are defined more than once...
 const duplicatedValuespaces = [
-  // Defined in CSS Grid Layout Module Level 2 and CSS Box Sizing Module Level 3
-  // https://drafts.csswg.org/css-grid-2/
-  // https://drafts.csswg.org/css-sizing-3/
-  '<fit-content()>',
-
-  // Defined in CSS Images Module Level 3, CSS Positioned Layout Module Level 3
-  // and CSS Text Module Level 3 (and CSS Values but in prose so not extracted)
-  // https://drafts.csswg.org/css-images-3/
-  // https://drafts.csswg.org/css-position/
-  // https://drafts.csswg.org/css-text-3/
-  '<length>',
-
   // Defined in CSS Shapes Module Level 1 and Motion Path Module Level 1
   // https://drafts.csswg.org/css-shapes/
   // https://drafts.fxtf.org/motion-1/
   '<path()>',
 
-  // Defined in CSS Positioned Layout Module Level 3,
-  // CSS Mobile Text Size Adjustment Module Level 1 and CSS Text Module Level 3
-  // (and CSS Values but in prose so not extracted)
-  // https://drafts.csswg.org/css-position/
-  // https://drafts.csswg.org/css-size-adjust-1/
-  // https://drafts.csswg.org/css-text-3/
-  '<percentage>',
-
   // Defined in CSS Masking Module Level 1 and CSS Shapes Module Level 1
   // https://drafts.fxtf.org/css-masking-1/
   // https://drafts.csswg.org/css-shapes/
-  '<rect()>',
-
-  // Defined in CSS Masking Module Level 1, CSS Values and Units Module Level 4
-  // and Filter Effects Module Level 1
-  // https://drafts.fxtf.org/css-masking-1/
-  // https://drafts.csswg.org/css-values-4/
-  // https://drafts.fxtf.org/filter-effects-1/
-  '<url>'
+  '<rect()>'
 ];
 
 
@@ -159,7 +129,7 @@ describe(`The curated view of CSS extracts`, () => {
     describe(`Looking at CSS valuespaces, the curated view`, () => {
       for (const [name, dfns] of Object.entries(valuespaces)) {
         if (duplicatedValuespaces.includes(name)) {
-          it(`contains more than "${name}" valuespace definitions`, () => {
+          it(`contains more than one "${name}" valuespace definitions`, () => {
             assert(dfns.length >= 2);
           });
         }

--- a/tools/drop-css-property-duplicates.js
+++ b/tools/drop-css-property-duplicates.js
@@ -25,6 +25,19 @@ const supersededBy = {
   // All CSS modules supersede CSS 2.x
   'CSS': '*',
 
+  // All unit value spaces defined in CSS values supersede re-definitions that
+  // just refine how the value needs to be interpreted in other specs
+  // (happens for <integer> and <url> for instance)
+  // NB: Reffy should rather take the `data-dfn-for` attribute to avoid having
+  // to deal with that here, see https://github.com/w3c/reffy/issues/980
+  'css-values': '*',
+
+  // CSS Images defines the <image> value space. CSS Content merely explains
+  // how it needs to be interpreted in the context of <content-list>
+  // NB: Reffy should rather take the `data-dfn-for` attribute to avoid having
+  // to deal with that here, see https://github.com/w3c/reffy/issues/980
+  'css-images': 'css-content',
+
   // See note in https://drafts.csswg.org/css-align/#placement
   // "The property definitions here supersede those in [CSS-FLEXBOX-1]"
   'css-flexbox': 'css-align',


### PR DESCRIPTION
The extraction of CSS value spaces based on `data-dfn-type` both removes a handful of cases where we ended up with duplicate value spaces definitions in CSS extracts, and produes a couple of additional ones for `<integer>`, `<url>` and `<image>`. This update drops the exceptions-to-the-rules in the tests and handles the additional duplicates generally by favoring definitions in CSS Values and CSS Images.

The additional duplicates should rather be handled by Reffy, or at least Reffy should report on the `data-dfn-for` attribute so that the location of the global definition is, see:
https://github.com/w3c/reffy/issues/980