### PR TITLE
[Curation] Add package.json file to curated branch

### DIFF
--- a/tools/commit-curated.js
+++ b/tools/commit-curated.js
@@ -60,6 +60,11 @@ async function commitCurated(curatedFolder, stayOnCurated) {
   console.log('- done');
 
   console.log();
+  console.log('Add package.json file to the "curated" branch');
+  execSync('git checkout main -- package.json');
+  console.log('- done');
+
+  console.log();
   console.log('Commit changes to the "curated" branch');
   execSync('git add ed --all');
   execSync(`git commit -m "Publish curated data from ${currentCommit}" -m "Curated data generated from raw data at ${currentCommit}" || echo ""`);


### PR DESCRIPTION
This should allow users to install the curated branch of Webref directly from npm and then import it from code (see #641):

```
npm install "https://github.com/w3c/webref.git#curated"
```

```js
import webref from 'webref/ed' assert { type: 'json' };
```

Note that we don't currently update the overall version of the Webref package (it stays at `0.0.1`) and don't provide the JS logic (`listAll`) that exists in the released `@webref/xxx` packages (that logic is in the `curated` branch but not in the `ed` folder).