### PR TITLE
Strip down package.json file in curated branch

### DIFF
--- a/tools/commit-curated.js
+++ b/tools/commit-curated.js
@@ -60,8 +60,13 @@ async function commitCurated(curatedFolder, stayOnCurated) {
   console.log('- done');
 
   console.log();
-  console.log('Add package.json file to the "curated" branch');
+  console.log('Add stripped down version of package.json to the "curated" branch');
   execSync('git checkout main -- package.json');
+  const packagejson = JSON.parse(await fs.readFile('package.json', 'utf8'));
+  delete packagejson.devDependencies;
+  delete packagejson.scripts;
+  await fs.writeFile('package.json', JSON.stringify(packagejson, null, 2), 'utf8');
+  execSync('git add package.json');
   console.log('- done');
 
   console.log();


### PR DESCRIPTION
Scripts and dependencies in the package.json file are useless in the curated branch, and problematic since underlying code does not exist in that branch, and since the `prepare` script is run automatically when the package gets installed.

Note: Instead of copying the `package.json` file from the main branch, another approach would be to maintain the file in the curated branch completely separately. I'm sticking to the copy approach for now.