### PR TITLE
Update patch for ed/idl/web-animations.idl

### DIFF
--- a/ed/idlpatches/web-animations.idl.patch
+++ b/ed/idlpatches/web-animations.idl.patch
@@ -1,20 +1,21 @@
-From 40c9939151bb56b1ed6e4c6cddc40f2a3bb5e882 Mon Sep 17 00:00:00 2001
+From 7a5a1a6981a5d347f3e262f736590567b643359a Mon Sep 17 00:00:00 2001
 From: Francois Daoust <fd@tidoust.net>
-Date: Thu, 30 Sep 2021 23:00:09 +0200
-Subject: [PATCH] Drop duplicate interfaces, dictionaries and properties
+Date: Sun, 17 Jul 2022 22:09:46 +0200
+Subject: [PATCH] [PATCH] Drop duplicate interfaces, dictionaries and
+ properties
 
 The terms are partially re-defined in Level 2. Patch is only needed because
 Level 2 is a delta spec. It will likely need to be kept around for as long
 as that remains the case.
 ---
- ed/idl/web-animations.idl | 18 ------------------
- 1 file changed, 18 deletions(-)
+ ed/idl/web-animations.idl | 19 -------------------
+ 1 file changed, 19 deletions(-)
 
 diff --git a/ed/idl/web-animations.idl b/ed/idl/web-animations.idl
-index 6e973d195..2b5f672b9 100644
+index 3fd59c0a1..f252441d2 100644
 --- a/ed/idl/web-animations.idl
 +++ b/ed/idl/web-animations.idl
-@@ -25,8 +25,6 @@ interface Animation : EventTarget {
+@@ -24,8 +24,6 @@ interface Animation : EventTarget {
               attribute DOMString                id;
               attribute AnimationEffect?         effect;
               attribute AnimationTimeline?       timeline;
@@ -23,7 +24,12 @@ index 6e973d195..2b5f672b9 100644
               attribute double                   playbackRate;
      readonly attribute AnimationPlayState       playState;
      readonly attribute AnimationReplaceState    replaceState;
-@@ -65,7 +63,6 @@ dictionary EffectTiming {
+@@ -57,12 +55,9 @@ interface AnimationEffect {
+ };
+ 
+ dictionary EffectTiming {
+-    double                             delay = 0;
+-    double                             endDelay = 0;
      FillMode                           fill = "auto";
      double                             iterationStart = 0.0;
      unrestricted double                iterations = 1.0;
@@ -31,7 +37,7 @@ index 6e973d195..2b5f672b9 100644
      PlaybackDirection                  direction = "normal";
      DOMString                          easing = "linear";
  };
-@@ -86,10 +83,7 @@ enum FillMode { "none", "forwards", "backwards", "both", "auto" };
+@@ -83,9 +78,6 @@ enum FillMode { "none", "forwards", "backwards", "both", "auto" };
  enum PlaybackDirection { "normal", "reverse", "alternate", "alternate-reverse" };
  
  dictionary ComputedEffectTiming : EffectTiming {
@@ -41,8 +47,7 @@ index 6e973d195..2b5f672b9 100644
      double?              progress;
      unrestricted double? currentIteration;
  };
- 
-@@ -158,14 +152,3 @@ partial interface mixin DocumentOrShadowRoot {
+@@ -155,14 +147,3 @@ partial interface mixin DocumentOrShadowRoot {
  };
  
  Element includes Animatable;
@@ -58,5 +63,5 @@ index 6e973d195..2b5f672b9 100644
 -    double? timelineTime = null;
 -};
 -- 
-2.31.1.windows.1
+2.36.0.windows.1
 


### PR DESCRIPTION
Re-generate patch to add suppression of `delay` and `endDelay`, now redefined in level 2.