### PR TITLE
Events package "listAll": don't preserve list in memory

### DIFF
--- a/packages/events/index.js
+++ b/packages/events/index.js
@@ -1,13 +1,9 @@
 const fs = require('fs').promises;
 const path = require('path');
-let events;
 
 async function listAll({folder = __dirname} = {}) {
-  if (!events) {
-    const json = await fs.readFile(path.join(folder, 'events.json'), 'utf8');
-    events = JSON.parse(json);
-  }
-  return events;
+  const json = await fs.readFile(path.join(folder, 'events.json'), 'utf8');
+  return JSON.parse(json);
 }
 
 module.exports = {listAll};


### PR DESCRIPTION
The `listAll` function should not assume that callers are willing to preserve the list of events in memory. Besides, if callers modify the list in place, they would expect another call to `listAll` to return a fresh list.