### PR TITLE
Fix event patches

### DIFF
--- a/tools/amend-event-data.js
+++ b/tools/amend-event-data.js
@@ -338,7 +338,7 @@ const patches = {
       change: { interface: "Event", bubbles: false }
     }
   ],
-  'service-workers-1': [
+  'service-workers': [
     {
       pattern: { href: "https://wicg.github.io/BackgroundSync/spec/#sync" },
       matched: 1,
@@ -423,6 +423,11 @@ const patches = {
       pattern: { type: "change" },
       matched: 1,
       delete: true
+    },
+    {
+      pattern: { type: "dequeue" },
+      matched: 4,
+      change: { interface: 'Event' }
     }
   ],
   // see also https://github.com/KhronosGroup/WebGL/issues/3349


### PR DESCRIPTION
The shortname of Service workers changed recently and needed to be updated. The WebCodecs added another event without using the proper language. Spec will need fixing, adding a patch in the meantime to resume data curation.