### PR TITLE
Drop event patch for "change" event in Web Codecs

### DIFF
--- a/tools/amend-event-data.js
+++ b/tools/amend-event-data.js
@@ -420,11 +420,6 @@ const patches = {
   ],
   'webcodecs': [
     {
-      pattern: { type: "change" },
-      matched: 1,
-      delete: true
-    },
-    {
       pattern: { type: "dequeue" },
       matched: 4,
       change: { interface: 'Event' }


### PR DESCRIPTION
Event was removed from the spec.

Note CI tests will continue to fail because of a hiccup with css-color that also needs fixing (but not in webref)