### PR TITLE
Add event test exception for css-contain-2

### DIFF
--- a/test/events/all.js
+++ b/test/events/all.js
@@ -131,6 +131,7 @@ before(async () => {
       assert.deepEqual(
         eventInterfaces.filter(iface => !usedEventInterfaces.has(iface)),
         [
+          'ContentVisibilityAutoStateChangedEvent', // pending https://github.com/w3c/csswg-drafts/issues/7603
           'CustomEvent', // not used by any spec
           'PaymentRequestUpdateEvent' // pending https://github.com/w3c/payment-request/issues/991
         ],


### PR DESCRIPTION
The `ContentVisibilityAutoStateChangedEvent` event interface is defined without any corresponding event type or event handler IDL attribute. This adds the interface to the list of expected failures pending resolution of https://github.com/w3c/csswg-drafts/issues/7603

Note CI tests will continue to fail because of a hiccup with css-color that also needs fixing (but not in webref)