### PR TITLE
Events: document bubblingPath property

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ Data curation brings the following guarantees.
 - All events have a `interface` attribute to describe the interface used by the Event. The Web IDL interface exists in the latest version of the [`@webref/idl` package](https://www.npmjs.com/package/@webref/idl) at the time the `@webref/events` package is released, and represents an actual interface (i.e. not a mixin).
 - All events have a `targets` attribute with a non-empty list of target interfaces on which the event may fire. All Web IDL interfaces in the list exist in the latest version of the [`@webref/idl` package](https://www.npmjs.com/package/@webref/idl) at the time the `@webref/events` package is released, and represent an actual interface (i.e. not a mixin).
 - The `bubbles` attribute is always set to a boolean value for target interfaces that belong to a bubbling tree (DOM, IndexedDB, Serial API, Web Bluetooth).
-- The `bubbles` attribute is not set for target interface that do not belong to a bubbling tree.
+- The `bubbles` attribute is only set for target interfaces that belong to a bubbling tree.
+- The `bubblingPath` attribute is only set for target interfaces on which the event bubbles.
 - The `targets` attribute contains the top most interfaces in an inheritance chain, unless bubbling conditions differ. For instance, the list may contain `{ "target": "Element", "bubbles": true }` but not also `{ "target": "HTMLElement", "bubbles": true }` since `HTMLElement` inherits from `Element`.
 - For target interfaces that belong to a bubbling tree, the `targets` attribute only contains the deepest interface in the bubbling tree on which the event may fire and bubble. For instance, the list may contain `{ "target": "HTMLElement", "bubbles": true }`, but not also `{ "target": "Document" }` since event would de facto fire at `Document` through bubbling.
 

--- a/packages/events/README.md
+++ b/packages/events/README.md
@@ -17,7 +17,14 @@ events.listAll().then(all => {
 });
 ```
 
-Each event is described by an object that has a `type` property that contains the name of the event, an `interface` property that describes the IDL interface used by the event, a `targets` property that lists the target interfaces on which the event may fire (each target being an object with a `target` property that gives the interface name, and optionally a `bubbles` property when the interface belongs to a bubbling tree to assert whether the event bubbles). The object may also contain a `href` property that is a URL to the event definition in a spec, and an `src` property that describes where the extraction first detected that the event is fired in the spec:
+Each event is described by an object with the following properties:
+- `type`: contains the name of the event
+- `interface`: describes the IDL interface used by the event
+- `targets`: lists the target interfaces on which the event may fire. Each target in the list is an object with a `target` property that gives the interface name, a `bubbles` property only set when the interface belongs to a bubbling tree to assert whether the event bubbles, and a `bubblingPath` property only when the event effectively bubbles and that lists the core interfaces on which the event can theoretically bubble.
+- optionally, an `href` property that is a URL to the event definition in a spec
+- optionally, an `src` property that describes where the extraction first detected that the event is fired in the spec
+
+The following example illustrates access to main properties:
 
 ```js
 const events = require('@webref/events');
@@ -35,6 +42,9 @@ events.listAll().then(all => {
 });
 ```
 
+Actual interfaces on which an event will bubble may be interfaces that inherit from the interfaces listed in `bubblingPath`. For instance, for a bubbling event that fires on `HTMLSelectElement`, the bubbling path will be `["Node", "Document", "Window"]`, even though the event will only bubble on `HTMLElement` and not on all types of `Node` in practice.
+
+
 # Guarantees
 
 The following guarantees are provided by this package:
@@ -42,6 +52,7 @@ The following guarantees are provided by this package:
 - All events have a `interface` attribute to describe the interface used by the Event. The Web IDL interface exists in the latest version of the [`@webref/idl` package](https://www.npmjs.com/package/@webref/idl) at the time the `@webref/events` package is released, and represents an actual interface (i.e. not a mixin).
 - All events have a `targets` attribute with a non-empty list of target interfaces on which the event may fire. All Web IDL interfaces in the list exist in the latest version of the [`@webref/idl` package](https://www.npmjs.com/package/@webref/idl) at the time the `@webref/events` package is released, and represent an actual interface (i.e. not a mixin).
 - The `bubbles` attribute is always set to a boolean value for target interfaces that belong to a bubbling tree (DOM, IndexedDB, Serial API, Web Bluetooth).
-- The `bubbles` attribute is not set for target interface that do not belong to a bubbling tree.
+- The `bubbles` attribute is only set for target interfaces that belong to a bubbling tree.
+- The `bubblingPath` attribute is only set for target interfaces on which the event bubbles.
 - The `targets` attribute contains the top most interfaces in an inheritance chain, unless bubbling conditions differ. For instance, the list may contain `{ "target": "Element", "bubbles": true }` but not also `{ "target": "HTMLElement", "bubbles": true }` since `HTMLElement` inherits from `Element`.
 - For target interfaces that belong to a bubbling tree, the `targets` attribute only contains the deepest interface in the bubbling tree on which the event may fire and bubble. For instance, the list may contain `{ "target": "HTMLElement", "bubbles": true }`, but not also `{ "target": "Document" }` since event would de facto fire at `Document` through bubbling.


### PR DESCRIPTION
This updates the events package README to document the `bubblingPath` property.