### PR TITLE
Update github actions to run on ubuntu-latest

### DIFF
--- a/.github/workflows/clean-patches.yml
+++ b/.github/workflows/clean-patches.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 jobs:
   clean:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout webref
       uses: actions/checkout@v2

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 jobs:
   update:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout webref
       uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2

--- a/.github/workflows/update-ed.yml
+++ b/.github/workflows/update-ed.yml
@@ -5,7 +5,7 @@ on:
 name: Update ED report
 jobs:
   update:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - name: Setup node.js
       uses: actions/setup-node@v2

--- a/.github/workflows/update-tr.yml
+++ b/.github/workflows/update-tr.yml
@@ -5,7 +5,7 @@ on:
 name: Update TR report
 jobs:
   update:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - name: Setup node.js
       uses: actions/setup-node@v2


### PR DESCRIPTION
ubuntu-18.04 getting deprecated in December
no clear reason not to use latest given our relatively vanilla jobs