### PR TITLE
Add event patch for css-contain-2

### DIFF
--- a/test/events/all.js
+++ b/test/events/all.js
@@ -131,7 +131,6 @@ before(async () => {
       assert.deepEqual(
         eventInterfaces.filter(iface => !usedEventInterfaces.has(iface)),
         [
-          'ContentVisibilityAutoStateChangedEvent', // pending https://github.com/w3c/csswg-drafts/issues/7603
           'CustomEvent', // not used by any spec
           'PaymentRequestUpdateEvent' // pending https://github.com/w3c/payment-request/issues/991
         ],

--- a/tools/amend-event-data.js
+++ b/tools/amend-event-data.js
@@ -121,6 +121,17 @@ const patches = {
       change: { interface: 'MediaQueryListEvent' }
     }
   ],
+  // pending resolution of https://github.com/w3c/csswg-drafts/issues/7603
+  // and https://github.com/w3c/csswg-drafts/pull/7740
+  // (note event type and interface name may change to use a verb in the present
+  // tense as part of the resolution)
+  'css-contain-2': [
+    {
+      pattern: { type: 'contentvisibilityautostatechanged' },
+      matched: 1,
+      change: { interface: 'ContentVisibilityAutoStateChangedEvent' }
+    }
+  ],
   'css-font-loading-3': [
     {
       pattern: { type: /^loading/ },


### PR DESCRIPTION
There already was an exception to the rule because the event type was not correctly defined and thus wasn't extracted as event type. The spec was updated recently and now correctly define the event type... but fails to associate it with the event interface.