### PR TITLE
Update patches for HTML spec that dropped "targets"

### DIFF
--- a/tools/amend-event-data.js
+++ b/tools/amend-event-data.js
@@ -219,7 +219,7 @@ const patches = {
     {
       pattern: { targets: "Elements" },
       matched: 3,
-      change: { targets: null }
+      change: { targets: ["Element"] }
     },
     {
       pattern: { href: /dnd.html#event-dnd/ },
@@ -261,11 +261,6 @@ const patches = {
       pattern: { type: "select"},
       matched: 1,
       change: { targets: ["HTMLInputElement", "HTMLTextAreaElement" ]}
-    },
-    {
-      pattern: { type: "slotchange"},
-      matched: 1,
-      change: { targets: null}
     },
     {
       pattern: { type: "toggle"},


### PR DESCRIPTION
The three events that get extracted with an "Elements" `targets` property are defined in UI Events and actually target `Element`. Updating the property accordingly.

I don't think HTML extends them in any way (other than firing them, that is), perhaps it would make sense not to extract them at all from the summary table at https://html.spec.whatwg.org/multipage/indices.html#events-2

The `slotchange` gets fired at `HTMLSlotElement` elements. That is correctly extracted by Reffy, so dropping the patch that updated the `targets` property. Or do I miss the reason why the patch was there in the first place?