### PR TITLE
Add patch for ed/idl/web-animations.idl

### DIFF
--- a/ed/idlpatches/web-animations.idl.patch
+++ b/ed/idlpatches/web-animations.idl.patch
@@ -1,19 +1,24 @@
-From 8e042105b7267a7f495547eacd304dd65664e295 Mon Sep 17 00:00:00 2001
+From ecafd75954ae61d1ec574b44b7e5da3c60be6131 Mon Sep 17 00:00:00 2001
 From: Francois Daoust <fd@tidoust.net>
-Date: Mon, 19 Sep 2022 17:10:41 +0200
-Subject: [PATCH] Add IDL patch for Web Animations
+Date: Mon, 19 Sep 2022 18:50:46 +0200
+Subject: [PATCH] [PATCH] Drop AnimationTimeline, adjust IDL terms in Web
+ Animations
 
 The `AnimationTimeline` interface is (temporarily) re-defined in Scroll
 Animations and will be merged in Web Animations. No specific tracking issue
 (issue appears as a note in the Scroll Animations ED) but this patch will fail
 as soon as the IDL in Web Animations gets updated, so we'll know when the patch
 can be dropped.
+
+Some other terms are partially re-defined in Level 2. Parts of the patch that
+update these definitions are only needed because Level 2 is a delta spec. They
+will likely need to be kept around for as long as that remains the case.
 ---
- ed/idl/web-animations.idl | 5 -----
- 1 file changed, 5 deletions(-)
+ ed/idl/web-animations.idl | 24 ------------------------
+ 1 file changed, 24 deletions(-)
 
 diff --git a/ed/idl/web-animations.idl b/ed/idl/web-animations.idl
-index 1b078e6ea..07df90672 100644
+index 1b078e6ea..6030dad33 100644
 --- a/ed/idl/web-animations.idl
 +++ b/ed/idl/web-animations.idl
 @@ -3,11 +3,6 @@
@@ -28,6 +33,53 @@ index 1b078e6ea..07df90672 100644
  dictionary DocumentTimelineOptions {
    DOMHighResTimeStamp originTime = 0;
  };
+@@ -24,8 +19,6 @@ interface Animation : EventTarget {
+              attribute DOMString                id;
+              attribute AnimationEffect?         effect;
+              attribute AnimationTimeline?       timeline;
+-             attribute double?                  startTime;
+-             attribute double?                  currentTime;
+              attribute double                   playbackRate;
+     readonly attribute AnimationPlayState       playState;
+     readonly attribute AnimationReplaceState    replaceState;
+@@ -58,12 +51,9 @@ interface AnimationEffect {
+ };
+ 
+ dictionary EffectTiming {
+-    double                             delay = 0;
+-    double                             endDelay = 0;
+     FillMode                           fill = "auto";
+     double                             iterationStart = 0.0;
+     unrestricted double                iterations = 1.0;
+-    (unrestricted double or DOMString) duration = "auto";
+     PlaybackDirection                  direction = "normal";
+     DOMString                          easing = "linear";
+ };
+@@ -84,9 +74,6 @@ enum FillMode { "none", "forwards", "backwards", "both", "auto" };
+ enum PlaybackDirection { "normal", "reverse", "alternate", "alternate-reverse" };
+ 
+ dictionary ComputedEffectTiming : EffectTiming {
+-    unrestricted double  endTime;
+-    unrestricted double  activeDuration;
+-    double?              localTime;
+     double?              progress;
+     unrestricted double? currentIteration;
+ };
+@@ -156,14 +143,3 @@ partial interface mixin DocumentOrShadowRoot {
+ };
+ 
+ Element includes Animatable;
+-
+-[Exposed=Window]
+-interface AnimationPlaybackEvent : Event {
+-    constructor(DOMString type, optional AnimationPlaybackEventInit eventInitDict = {});
+-    readonly attribute double? currentTime;
+-    readonly attribute double? timelineTime;
+-};
+-dictionary AnimationPlaybackEventInit : EventInit {
+-    double? currentTime = null;
+-    double? timelineTime = null;
+-};
 -- 
 2.36.0.windows.1
 


### PR DESCRIPTION
I completely missed the fact that there already existed an IDL patch for Web Animations. Previous PR #736, which was merged, overwrote that patch by mistake. The previous updates are still needed. That explains why CI tests failed, and should have been yet another signal that something was wrong ;)

This new PR merges the previous patch and the new one.