### PR TITLE
Fix href URL for cut, copy and paste events patches

### DIFF
--- a/tools/amend-event-data.js
+++ b/tools/amend-event-data.js
@@ -75,7 +75,7 @@ const patches = {
         interface: "ClipboardEvent",
         targets: ["DocumentAndElementEventHandlers"],
         bubbles: true,
-        href: "https://w3c.github.io/clipboard-apis/#clipboardchange"
+        href: "https://w3c.github.io/clipboard-apis/#copy"
       }
     },
     {
@@ -84,7 +84,7 @@ const patches = {
         interface: "ClipboardEvent",
         targets: ["DocumentAndElementEventHandlers"],
         bubbles: true,
-        href: "https://w3c.github.io/clipboard-apis/#clipboardchange"
+        href: "https://w3c.github.io/clipboard-apis/#cut"
       }
     },
     {
@@ -93,7 +93,7 @@ const patches = {
         interface: "ClipboardEvent",
         targets: ["DocumentAndElementEventHandlers"],
         bubbles: true,
-        href: "https://w3c.github.io/clipboard-apis/#clipboardchange"
+        href: "https://w3c.github.io/clipboard-apis/#paste"
       }
     },
   ],


### PR DESCRIPTION
The URLs all targeted `clipboardchange`.

Note this update just fixes the URLs. It won't solve the Clipboard APIs / HTML duplication raised in:
https://github.com/w3c/webref/pull/729#issuecomment-1253812086