### PR TITLE
Adjust event patches for the "slotchange" event

### DIFF
--- a/tools/amend-event-data.js
+++ b/tools/amend-event-data.js
@@ -561,7 +561,7 @@ function applyEventPatches(spec) {
           continue;
         } else if (patch.change) {
           for (const target of Object.keys(patch.change)) {
-            if (patch.change[target]) {
+            if (patch.change[target] !== null) {
               event[target] = patch.change[target];
             }
             else {


### PR DESCRIPTION
Goal is to make sure that the `slotchange` event is listed as firing at a `HTMLSlotElement` element and bubbles, instead of firing at `ShadowRoot`.

This will lead to the following event definition in the consolidated list:

```json
{
  "href": "https://html.spec.whatwg.org/multipage/indices.html#event-slotchange",
  "src": {
    "format": "summary table",
    "href": "https://html.spec.whatwg.org/multipage/indices.html#event-slotchange"
  },
  "type": "slotchange",
  "targets": [
    {
      "target": "HTMLSlotElement",
      "bubbles": true,
      "bubblingPath": [
        "Node",
        "Document",
        "Window"
      ]
    }
  ],
  "interface": "Event",
  "extendedIn": [
    {
      "spec": "dom",
      "href": "https://dom.spec.whatwg.org/#ref-for-concept-event-fire%E2%91%A5"
    }
  ]
}
```

Treatment of `ShadowRoot` could still be improved: the bubbling path does mention `Node`, so event can indeed fire at `ShadowRoot`. That said, the `slotchange` is the only event that can fire at `ShadowRoot`, which seems worth calling out. I don't know how to do that with the current structure and logic though.