### PR TITLE
Validate JSON data against schemas

### DIFF
--- a/test/schemas.js
+++ b/test/schemas.js
@@ -1,0 +1,41 @@
+/**
+ * Test individual elements extracts against JSON schemas.
+ * 
+ * The tests run against the curated view of the extracts.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert').strict;
+const { getSchemaValidationFunction } = require('reffy');
+
+const curatedFolder = path.join(__dirname, '..', 'curated');
+const files = fs.readdirSync(curatedFolder);
+for (const file of files) {
+  const validate = getSchemaValidationFunction(file);
+  if (file.endsWith('.json')) {
+    describe(`The ${file} file`, function () {
+      it('contains valid data', function () {
+        const data = require(path.join(curatedFolder, file));
+        const errors = validate(data);
+        assert.strictEqual(errors, null, JSON.stringify(errors, null, 2));
+      });
+    });
+  }
+  else {
+    describe(`The ${file} folder`, function () {
+      const extractType = file;
+      const folder = path.join(curatedFolder, extractType);
+      const files = fs.readdirSync(folder);
+      for (const file of files) {
+        if (file.endsWith('.json')) {
+          it(`contains valid ${extractType} data in ${file}`, () => {
+            const data = require(path.join(folder, file));
+            const errors = validate(data);
+            assert.strictEqual(errors, null, JSON.stringify(errors, null, 2));
+          });
+        }
+      }
+    });
+  }
+}


### PR DESCRIPTION
This makes use of the new schema validation function in Reffy to make sure that the curated data Webref produces follow expected scheams, see:
  https://github.com/w3c/reffy/pull/1075

This replaces #731 and fixes #657.

Schemas, notably those that deal with parsed IDL structures, could go deeper into details. To be improved over time.

Tests are run against the curated version of data. That is not necessary for extracts that aren't actually curated (dfns, headings, ids, links, refs), just more convenient not to have branching logic in the test code.