### PR TITLE
Adjust event patches for screen orientation

### DIFF
--- a/tools/amend-event-data.js
+++ b/tools/amend-event-data.js
@@ -351,8 +351,8 @@ const patches = {
   'screen-orientation': [
     {
       pattern: { type: 'change' },
-      matched: 1,
-      change: { interface: 'Event' }
+      matched: 2,
+      change: { interface: 'Event', targets: [ 'ScreenOrientation' ] }
     }
   ],
   'selection-api': [


### PR DESCRIPTION
Event is fired twice in the spec.