### PR TITLE
Fix CSS superseding relationship for css-values

### DIFF
--- a/tools/drop-css-property-duplicates.js
+++ b/tools/drop-css-property-duplicates.js
@@ -30,13 +30,9 @@ const supersededBy = {
   // (happens for <integer> and <url> for instance)
   // NB: Reffy should rather take the `data-dfn-for` attribute to avoid having
   // to deal with that here, see https://github.com/w3c/reffy/issues/980
-  'css-values': '*',
-
-  // CSS Images defines the <image> value space. CSS Content merely explains
-  // how it needs to be interpreted in the context of <content-list>
-  // NB: Reffy should rather take the `data-dfn-for` attribute to avoid having
-  // to deal with that here, see https://github.com/w3c/reffy/issues/980
-  'css-images': 'css-content',
+  'css-backgrounds': 'css-values',
+  'css-fonts': 'css-values',
+  'filter-effects': 'css-values',
 
   // See note in https://drafts.csswg.org/css-align/#placement
   // "The property definitions here supersede those in [CSS-FLEXBOX-1]"


### PR DESCRIPTION
Fixes #794.

`css-values` was incorrectly marked as being superseded by everything else instead of actually superseding other specs. The list of specs being superseded is now explicit.

The update also drops the `css-content > css-images` relationship, which was reversed too and is now useless in any case.

Note this whole logic should soon more or less disappear with the next major version of Reffy which supports `data-dfn-for` attributes and distinguishes between CSS values that are namespaced from those that are not.