### PR TITLE
Fix name of extract file in CSS superseding logic

### DIFF
--- a/tools/drop-css-property-duplicates.js
+++ b/tools/drop-css-property-duplicates.js
@@ -184,7 +184,10 @@ async function dropCSSPropertyDuplicates(folder) {
       }
     }, spec.css);
     const json = JSON.stringify(css, null, 2) + '\n';
-    const pathname = path.join(folder, 'css', spec.series.shortname + '.json')
+    const filename = spec.shortname === spec.series.currentSpecification ?
+      spec.series.shortname :
+      spec.shortname
+    const pathname = path.join(folder, 'css', filename + '.json');
     await fs.writeFile(pathname, json);
   };
 


### PR DESCRIPTION
The code assumed that CSS extracts were always named after the spec's series' shortname but that is not the case for specs that are not the current spec in the series.

Note this bug was sitting around, patiently waiting for an occasion to reveal itself. The recent fix on css-values superseding rules activated it because the code now drops `<position>` from the css-backgrounds-4 export, and current spec is css-backgrounds-3.