### PR TITLE
Prepare release: Enlarge size of stdout buffer for diff command

### DIFF
--- a/tools/prepare-release.js
+++ b/tools/prepare-release.js
@@ -79,10 +79,12 @@ function computeDiff(type) {
   // The "diff" command exits with a non zero status code when there is a diff,
   // which would throw an exception. Final "echo" command turns that status
   // code to 0 to avoid the exception.
+  // Note diff can be very large when the structure of all extracts are changed,
+  // hence the need to enlarge the size of the stdout/stderr buffer.
   const installedFiles = path.join(tmpFolder, "node_modules", "@webref", type);
   let diff = execSync(
     `diff ${installedFiles} packages/${type} --ignore-trailing-space --exclude=package.json --exclude=README.md --unified=3 || echo -n`,
-    { encoding: "utf8" });
+    { encoding: "utf8", maxBuffer: 100 * 1024 * 1024 });
 
   const diffReadme = execSync(
     `diff ${installedFiles}/README.md packages/${type}/README.md --ignore-trailing-space --unified=3 || echo -n`,


### PR DESCRIPTION
The diff command can produce a very large diff if the diff is the result of a major change to the structure of the extracts. Default size for the buffer in Node.js is 1MB. This update allows the diff command to produce up to 100MB of data.

This should unblock the curation job following the adjustments made to CSS extracts, e.g. see error in https://github.com/w3c/webref/actions/runs/3566152344/jobs/5992230191