### PR TITLE
Relax test on elements extracts

### DIFF
--- a/test/elements/all.js
+++ b/test/elements/all.js
@@ -26,7 +26,6 @@ describe('The curated view of elements extracts', function () {
       assert(desc.elements);
       assert(desc.elements.length > 0);
       assert(desc.elements[0].hasOwnProperty('name'));
-      assert(desc.elements[0].hasOwnProperty('interface'));
     }
   });
 });


### PR DESCRIPTION
The `interface` property may not always be set, even if one only considers the first item in the list.