### PR TITLE
Add patch for ed/idl/priority-hints.idl

### DIFF
--- a/ed/idlpatches/priority-hints.idl.patch
+++ b/ed/idlpatches/priority-hints.idl.patch
@@ -1,0 +1,36 @@
+From b60578262795f585935fe3b1618a6649f0ff216b Mon Sep 17 00:00:00 2001
+From: Francois Daoust <fd@tidoust.net>
+Date: Thu, 15 Dec 2022 21:29:25 +0100
+Subject: [PATCH] Drop interfaces integrated in Fetch
+
+Pending integration in HTML and removal from browser-specs:
+https://github.com/whatwg/html/pull/8470
+https://github.com/w3c/browser-specs/pull/791
+---
+ ed/idl/priority-hints.idl | 10 ----------
+ 1 file changed, 10 deletions(-)
+
+diff --git a/ed/idl/priority-hints.idl b/ed/idl/priority-hints.idl
+index 15c90bbe1..cbff6a522 100644
+--- a/ed/idl/priority-hints.idl
++++ b/ed/idl/priority-hints.idl
+@@ -3,16 +3,6 @@
+ // (https://github.com/w3c/webref)
+ // Source: Priority Hints (https://wicg.github.io/priority-hints/)
+ 
+-enum FetchPriority { "high", "low", "auto" };
+-
+-partial interface Request {
+-  readonly attribute FetchPriority priority;
+-};
+-
+-partial dictionary RequestInit {
+-  FetchPriority priority;
+-};
+-
+ partial interface HTMLImageElement {
+     [CEReactions] attribute DOMString fetchPriority;
+ };
+-- 
+2.39.0.windows.1
+


### PR DESCRIPTION
Drop interfaces integrated in Fetch pending integration in HTML and removal of the spec from browser-specs