### PR TITLE
Adjust jobs to use new patchdfns module in Reffy

### DIFF
--- a/.github/workflows/update-ed.yml
+++ b/.github/workflows/update-ed.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Run Reffy's crawler
       run: |
         mkdir report
-        node_modules/.bin/reffy --post csscomplete --post annotatelinks --output report --fallback webref-fallback/ed/index.json
+        node_modules/.bin/reffy --post csscomplete --post annotatelinks --post patchdfns --output report --fallback webref-fallback/ed/index.json
 
     - name: Checkout webref
       uses: actions/checkout@v2

--- a/.github/workflows/update-tr.yml
+++ b/.github/workflows/update-tr.yml
@@ -15,10 +15,18 @@ jobs:
     - name: Install reffy
       run: npm install reffy
 
+    # Use a separate checkout to reduce the chances
+    # that, by the time the crawl has ended, the underlying webref checkout
+    # that gets updated be no longer in sync with origin
+    - name: Checkout webref-fallback
+      uses: actions/checkout@v2
+      with:
+        path: webref-fallback
+
     - name: Run Reffy's crawler
       run: |
         mkdir report
-        node_modules/.bin/reffy --release --post csscomplete  --post annotatelinks --output report
+        node_modules/.bin/reffy --release --post csscomplete --post annotatelinks --post patchdfns --output report --fallback webref-fallback/tr/index.json
 
     - name: Checkout webref
       uses: actions/checkout@v2


### PR DESCRIPTION
Also adjust the TR job to make use of the fallback mechanism. If dfns created by the TR job are referenced from other tools, that seems useful.