### PR TITLE
Add IDL patch for ed/idl/DOM-Style.idl

### DIFF
--- a/ed/idlpatches/DOM-Style.idl.patch
+++ b/ed/idlpatches/DOM-Style.idl.patch
@@ -1,0 +1,1339 @@
+From 0df6fdf63ddbc69e2236310a92f719227811416c Mon Sep 17 00:00:00 2001
+From: Francois Daoust <fd@tidoust.net>
+Date: Mon, 9 Jan 2023 15:47:07 +0100
+Subject: [PATCH] Drop IDL extract from DOM-Level-2-Style
+
+The spec has been superseded and uses old style Web IDL. Reffy could perhaps
+ignore such specs not to produce IDL extracts that can only create conflicts
+(but then, DOM-Level-2-Style should remain an exception-to-the-rule).
+---
+ ed/idl/DOM-Style.idl | 1317 ------------------------------------------
+ 1 file changed, 1317 deletions(-)
+ delete mode 100644 ed/idl/DOM-Style.idl
+
+diff --git a/ed/idl/DOM-Style.idl b/ed/idl/DOM-Style.idl
+deleted file mode 100644
+index 8048999bf..000000000
+--- a/ed/idl/DOM-Style.idl
++++ /dev/null
+@@ -1,1317 +0,0 @@
+-// GENERATED CONTENT - DO NOT EDIT
+-// Content was automatically extracted by Reffy into webref
+-// (https://github.com/w3c/webref)
+-// Source: Document Object Model (DOM) Level 2 Style Specification (https://www.w3.org/TR/DOM-Level-2-Style/)
+-
+-// Introduced in DOM Level 2:
+-interface StyleSheet {
+-  readonly attribute DOMString        type;
+-           attribute boolean          disabled;
+-  readonly attribute Node             ownerNode;
+-  readonly attribute StyleSheet       parentStyleSheet;
+-  readonly attribute DOMString        href;
+-  readonly attribute DOMString        title;
+-  readonly attribute MediaList        media;
+-};
+-
+-// Introduced in DOM Level 2:
+-interface StyleSheetList {
+-  readonly attribute unsigned long    length;
+-  StyleSheet         item(in unsigned long index);
+-};
+-
+-// Introduced in DOM Level 2:
+-interface MediaList {
+-           attribute DOMString        mediaText;
+-                                        // raises(DOMException) on setting
+-
+-  readonly attribute unsigned long    length;
+-  DOMString          item(in unsigned long index);
+-  void               deleteMedium(in DOMString oldMedium)
+-                                        raises(DOMException);
+-  void               appendMedium(in DOMString newMedium)
+-                                        raises(DOMException);
+-};
+-
+-// Introduced in DOM Level 2:
+-interface LinkStyle {
+-  readonly attribute StyleSheet       sheet;
+-};
+-
+-// Introduced in DOM Level 2:
+-interface DocumentStyle {
+-  readonly attribute StyleSheetList   styleSheets;
+-};
+-
+-// Introduced in DOM Level 2:
+-interface CSSStyleSheet : stylesheets::StyleSheet {
+-  readonly attribute CSSRule          ownerRule;
+-  readonly attribute CSSRuleList      cssRules;
+-  unsigned long      insertRule(in DOMString rule,
+-                                in unsigned long index)
+-                                        raises(DOMException);
+-  void               deleteRule(in unsigned long index)
+-                                        raises(DOMException);
+-};
+-
+-// Introduced in DOM Level 2:
+-interface CSSRuleList {
+-  readonly attribute unsigned long    length;
+-  CSSRule            item(in unsigned long index);
+-};
+-
+-// Introduced in DOM Level 2:
+-interface CSSRule {
+-
+-  // RuleType
+-  const unsigned short      UNKNOWN_RULE                   = 0;
+-  const unsigned short      STYLE_RULE                     = 1;
+-  const unsigned short      CHARSET_RULE                   = 2;
+-  const unsigned short      IMPORT_RULE                    = 3;
+-  const unsigned short      MEDIA_RULE                     = 4;
+-  const unsigned short      FONT_FACE_RULE                 = 5;
+-  const unsigned short      PAGE_RULE                      = 6;
+-
+-  readonly attribute unsigned short   type;
+-           attribute DOMString        cssText;
+-                                        // raises(DOMException) on setting
+-
+-  readonly attribute CSSStyleSheet    parentStyleSheet;
+-  readonly attribute CSSRule          parentRule;
+-};
+-
+-// Introduced in DOM Level 2:
+-interface CSSStyleRule : CSSRule {
+-           attribute DOMString        selectorText;
+-                                        // raises(DOMException) on setting
+-
+-  readonly attribute CSSStyleDeclaration  style;
+-};
+-
+-// Introduced in DOM Level 2:
+-interface CSSMediaRule : CSSRule {
+-  readonly attribute stylesheets::MediaList  media;
+-  readonly attribute CSSRuleList      cssRules;
+-  unsigned long      insertRule(in DOMString rule,
+-                                in unsigned long index)
+-                                        raises(DOMException);
+-  void               deleteRule(in unsigned long index)
+-                                        raises(DOMException);
+-};
+-
+-// Introduced in DOM Level 2:
+-interface CSSFontFaceRule : CSSRule {
+-  readonly attribute CSSStyleDeclaration  style;
+-};
+-
+-// Introduced in DOM Level 2:
+-interface CSSPageRule : CSSRule {
+-           attribute DOMString        selectorText;
+-                                        // raises(DOMException) on setting
+-
+-  readonly attribute CSSStyleDeclaration  style;
+-};
+-
+-// Introduced in DOM Level 2:
+-interface CSSImportRule : CSSRule {
+-  readonly attribute DOMString        href;
+-  readonly attribute stylesheets::MediaList  media;
+-  readonly attribute CSSStyleSheet    styleSheet;
+-};
+-
+-// Introduced in DOM Level 2:
+-interface CSSCharsetRule : CSSRule {
+-           attribute DOMString        encoding;
+-                                        // raises(DOMException) on setting
+-
+-};
+-
+-// Introduced in DOM Level 2:
+-interface CSSUnknownRule : CSSRule {
+-};
+-
+-// Introduced in DOM Level 2:
+-interface CSSStyleDeclaration {
+-           attribute DOMString        cssText;
+-                                        // raises(DOMException) on setting
+-
+-  DOMString          getPropertyValue(in DOMString propertyName);
+-  CSSValue           getPropertyCSSValue(in DOMString propertyName);
+-  DOMString          removeProperty(in DOMString propertyName)
+-                                        raises(DOMException);
+-  DOMString          getPropertyPriority(in DOMString propertyName);
+-  void               setProperty(in DOMString propertyName,
+-                                 in DOMString value,
+-                                 in DOMString priority)
+-                                        raises(DOMException);
+-  readonly attribute unsigned long    length;
+-  DOMString          item(in unsigned long index);
+-  readonly attribute CSSRule          parentRule;
+-};
+-
+-// Introduced in DOM Level 2:
+-interface CSSValue {
+-
+-  // UnitTypes
+-  const unsigned short      CSS_INHERIT                    = 0;
+-  const unsigned short      CSS_PRIMITIVE_VALUE            = 1;
+-  const unsigned short      CSS_VALUE_LIST                 = 2;
+-  const unsigned short      CSS_CUSTOM                     = 3;
+-
+-           attribute DOMString        cssText;
+-                                        // raises(DOMException) on setting
+-
+-  readonly attribute unsigned short   cssValueType;
+-};
+-
+-// Introduced in DOM Level 2:
+-interface CSSPrimitiveValue : CSSValue {
+-
+-  // UnitTypes
+-  const unsigned short      CSS_UNKNOWN                    = 0;
+-  const unsigned short      CSS_NUMBER                     = 1;
+-  const unsigned short      CSS_PERCENTAGE                 = 2;
+-  const unsigned short      CSS_EMS                        = 3;
+-  const unsigned short      CSS_EXS                        = 4;
+-  const unsigned short      CSS_PX                         = 5;
+-  const unsigned short      CSS_CM                         = 6;
+-  const unsigned short      CSS_MM                         = 7;
+-  const unsigned short      CSS_IN                         = 8;
+-  const unsigned short      CSS_PT                         = 9;
+-  const unsigned short      CSS_PC                         = 10;
+-  const unsigned short      CSS_DEG                        = 11;
+-  const unsigned short      CSS_RAD                        = 12;
+-  const unsigned short      CSS_GRAD                       = 13;
+-  const unsigned short      CSS_MS                         = 14;
+-  const unsigned short      CSS_S                          = 15;
+-  const unsigned short      CSS_HZ                         = 16;
+-  const unsigned short      CSS_KHZ                        = 17;
+-  const unsigned short      CSS_DIMENSION                  = 18;
+-  const unsigned short      CSS_STRING                     = 19;
+-  const unsigned short      CSS_URI                        = 20;
+-  const unsigned short      CSS_IDENT                      = 21;
+-  const unsigned short      CSS_ATTR                       = 22;
+-  const unsigned short      CSS_COUNTER                    = 23;
+-  const unsigned short      CSS_RECT                       = 24;
+-  const unsigned short      CSS_RGBCOLOR                   = 25;
+-
+-  readonly attribute unsigned short   primitiveType;
+-  void               setFloatValue(in unsigned short unitType,
+-                                   in float floatValue)
+-                                        raises(DOMException);
+-  float              getFloatValue(in unsigned short unitType)
+-                                        raises(DOMException);
+-  void               setStringValue(in unsigned short stringType,
+-                                    in DOMString stringValue)
+-                                        raises(DOMException);
+-  DOMString          getStringValue()
+-                                        raises(DOMException);
+-  Counter            getCounterValue()
+-                                        raises(DOMException);
+-  Rect               getRectValue()
+-                                        raises(DOMException);
+-  RGBColor           getRGBColorValue()
+-                                        raises(DOMException);
+-};
+-
+-// Introduced in DOM Level 2:
+-interface CSSValueList : CSSValue {
+-  readonly attribute unsigned long    length;
+-  CSSValue           item(in unsigned long index);
+-};
+-
+-// Introduced in DOM Level 2:
+-interface RGBColor {
+-  readonly attribute CSSPrimitiveValue  red;
+-  readonly attribute CSSPrimitiveValue  green;
+-  readonly attribute CSSPrimitiveValue  blue;
+-};
+-
+-// Introduced in DOM Level 2:
+-interface Rect {
+-  readonly attribute CSSPrimitiveValue  top;
+-  readonly attribute CSSPrimitiveValue  right;
+-  readonly attribute CSSPrimitiveValue  bottom;
+-  readonly attribute CSSPrimitiveValue  left;
+-};
+-
+-// Introduced in DOM Level 2:
+-interface Counter {
+-  readonly attribute DOMString        identifier;
+-  readonly attribute DOMString        listStyle;
+-  readonly attribute DOMString        separator;
+-};
+-
+-// Introduced in DOM Level 2:
+-interface ViewCSS : views::AbstractView {
+-  CSSStyleDeclaration getComputedStyle(in Element elt,
+-                                       in DOMString pseudoElt);
+-};
+-
+-// Introduced in DOM Level 2:
+-interface DocumentCSS : stylesheets::DocumentStyle {
+-  CSSStyleDeclaration getOverrideStyle(in Element elt,
+-                                       in DOMString pseudoElt);
+-};
+-
+-// Introduced in DOM   Level 2:
+-interface DOMImplementationCSS : DOMImplementation {
+-  CSSStyleSheet      createCSSStyleSheet(in DOMString title,
+-                                         in DOMString media)
+-                                        raises(DOMException);
+-};
+-
+-// Introduced in DOM Level 2:
+-interface ElementCSSInlineStyle {
+-  readonly attribute CSSStyleDeclaration  style;
+-};
+-
+-// Introduced in DOM Level 2:
+-interface CSS2Properties {
+-           attribute DOMString        azimuth;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        background;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        backgroundAttachment;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        backgroundColor;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        backgroundImage;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        backgroundPosition;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        backgroundRepeat;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        border;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        borderCollapse;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        borderColor;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        borderSpacing;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        borderStyle;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        borderTop;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        borderRight;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        borderBottom;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        borderLeft;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        borderTopColor;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        borderRightColor;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        borderBottomColor;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        borderLeftColor;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        borderTopStyle;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        borderRightStyle;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        borderBottomStyle;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        borderLeftStyle;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        borderTopWidth;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        borderRightWidth;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        borderBottomWidth;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        borderLeftWidth;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        borderWidth;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        bottom;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        captionSide;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        clear;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        clip;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        color;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        content;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        counterIncrement;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        counterReset;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        cue;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        cueAfter;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        cueBefore;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        cursor;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        direction;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        display;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        elevation;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        emptyCells;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        cssFloat;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        font;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        fontFamily;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        fontSize;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        fontSizeAdjust;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        fontStretch;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        fontStyle;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        fontVariant;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        fontWeight;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        height;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        left;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        letterSpacing;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        lineHeight;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        listStyle;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        listStyleImage;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        listStylePosition;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        listStyleType;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        margin;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        marginTop;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        marginRight;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        marginBottom;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        marginLeft;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        markerOffset;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        marks;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        maxHeight;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        maxWidth;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        minHeight;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        minWidth;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        orphans;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        outline;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        outlineColor;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        outlineStyle;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        outlineWidth;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        overflow;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        padding;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        paddingTop;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        paddingRight;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        paddingBottom;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        paddingLeft;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        page;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        pageBreakAfter;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        pageBreakBefore;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        pageBreakInside;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        pause;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        pauseAfter;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        pauseBefore;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        pitch;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        pitchRange;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        playDuring;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        position;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        quotes;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        richness;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        right;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        size;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        speak;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        speakHeader;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        speakNumeral;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        speakPunctuation;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        speechRate;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        stress;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        tableLayout;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        textAlign;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        textDecoration;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        textIndent;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        textShadow;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        textTransform;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        top;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        unicodeBidi;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        verticalAlign;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        visibility;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        voiceFamily;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        volume;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        whiteSpace;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        widows;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        width;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        wordSpacing;
+-                                        // raises(DOMException) on setting
+-
+-           attribute DOMString        zIndex;
+-                                        // raises(DOMException) on setting
+-
+-};
+-
+-// File: stylesheets.idl
+-
+-#ifndef _STYLESHEETS_IDL_
+-#define _STYLESHEETS_IDL_
+-
+-#include "dom.idl"
+-
+-#pragma prefix "dom.w3c.org"
+-module stylesheets
+-{
+-
+-  typedef dom::DOMString DOMString;
+-  typedef dom::Node Node;
+-
+-  interface MediaList;
+-
+-  // Introduced in DOM Level 2:
+-  interface StyleSheet {
+-    readonly attribute DOMString        type;
+-             attribute boolean          disabled;
+-    readonly attribute Node             ownerNode;
+-    readonly attribute StyleSheet       parentStyleSheet;
+-    readonly attribute DOMString        href;
+-    readonly attribute DOMString        title;
+-    readonly attribute MediaList        media;
+-  };
+-
+-  // Introduced in DOM Level 2:
+-  interface StyleSheetList {
+-    readonly attribute unsigned long    length;
+-    StyleSheet         item(in unsigned long index);
+-  };
+-
+-  // Introduced in DOM Level 2:
+-  interface MediaList {
+-             attribute DOMString        mediaText;
+-                                        // raises(dom::DOMException) on setting
+-
+-    readonly attribute unsigned long    length;
+-    DOMString          item(in unsigned long index);
+-    void               deleteMedium(in DOMString oldMedium)
+-                                        raises(dom::DOMException);
+-    void               appendMedium(in DOMString newMedium)
+-                                        raises(dom::DOMException);
+-  };
+-
+-  // Introduced in DOM Level 2:
+-  interface LinkStyle {
+-    readonly attribute StyleSheet       sheet;
+-  };
+-
+-  // Introduced in DOM Level 2:
+-  interface DocumentStyle {
+-    readonly attribute StyleSheetList   styleSheets;
+-  };
+-};
+-
+-#endif // _STYLESHEETS_IDL_
+-
+-// File: css.idl
+-
+-#ifndef _CSS_IDL_
+-#define _CSS_IDL_
+-
+-#include "dom.idl"
+-#include "stylesheets.idl"
+-#include "views.idl"
+-
+-#pragma prefix "dom.w3c.org"
+-module css
+-{
+-
+-  typedef dom::DOMString DOMString;
+-  typedef dom::Element Element;
+-  typedef dom::DOMImplementation DOMImplementation;
+-
+-  interface CSSRule;
+-  interface CSSStyleSheet;
+-  interface CSSStyleDeclaration;
+-  interface CSSValue;
+-  interface Counter;
+-  interface Rect;
+-  interface RGBColor;
+-
+-  // Introduced in DOM Level 2:
+-  interface CSSRuleList {
+-    readonly attribute unsigned long    length;
+-    CSSRule            item(in unsigned long index);
+-  };
+-
+-  // Introduced in DOM Level 2:
+-  interface CSSRule {
+-
+-    // RuleType
+-    const unsigned short      UNKNOWN_RULE                   = 0;
+-    const unsigned short      STYLE_RULE                     = 1;
+-    const unsigned short      CHARSET_RULE                   = 2;
+-    const unsigned short      IMPORT_RULE                    = 3;
+-    const unsigned short      MEDIA_RULE                     = 4;
+-    const unsigned short      FONT_FACE_RULE                 = 5;
+-    const unsigned short      PAGE_RULE                      = 6;
+-
+-    readonly attribute unsigned short   type;
+-             attribute DOMString        cssText;
+-                                        // raises(dom::DOMException) on setting
+-
+-    readonly attribute CSSStyleSheet    parentStyleSheet;
+-    readonly attribute CSSRule          parentRule;
+-  };
+-
+-  // Introduced in DOM Level 2:
+-  interface CSSStyleRule : CSSRule {
+-             attribute DOMString        selectorText;
+-                                        // raises(dom::DOMException) on setting
+-
+-    readonly attribute CSSStyleDeclaration  style;
+-  };
+-
+-  // Introduced in DOM Level 2:
+-  interface CSSMediaRule : CSSRule {
+-    readonly attribute stylesheets::MediaList  media;
+-    readonly attribute CSSRuleList      cssRules;
+-    unsigned long      insertRule(in DOMString rule,
+-                                  in unsigned long index)
+-                                        raises(dom::DOMException);
+-    void               deleteRule(in unsigned long index)
+-                                        raises(dom::DOMException);
+-  };
+-
+-  // Introduced in DOM Level 2:
+-  interface CSSFontFaceRule : CSSRule {
+-    readonly attribute CSSStyleDeclaration  style;
+-  };
+-
+-  // Introduced in DOM Level 2:
+-  interface CSSPageRule : CSSRule {
+-             attribute DOMString        selectorText;
+-                                        // raises(dom::DOMException) on setting
+-
+-    readonly attribute CSSStyleDeclaration  style;
+-  };
+-
+-  // Introduced in DOM Level 2:
+-  interface CSSImportRule : CSSRule {
+-    readonly attribute DOMString        href;
+-    readonly attribute stylesheets::MediaList  media;
+-    readonly attribute CSSStyleSheet    styleSheet;
+-  };
+-
+-  // Introduced in DOM Level 2:
+-  interface CSSCharsetRule : CSSRule {
+-             attribute DOMString        encoding;
+-                                        // raises(dom::DOMException) on setting
+-
+-  };
+-
+-  // Introduced in DOM Level 2:
+-  interface CSSUnknownRule : CSSRule {
+-  };
+-
+-  // Introduced in DOM Level 2:
+-  interface CSSStyleDeclaration {
+-             attribute DOMString        cssText;
+-                                        // raises(dom::DOMException) on setting
+-
+-    DOMString          getPropertyValue(in DOMString propertyName);
+-    CSSValue           getPropertyCSSValue(in DOMString propertyName);
+-    DOMString          removeProperty(in DOMString propertyName)
+-                                        raises(dom::DOMException);
+-    DOMString          getPropertyPriority(in DOMString propertyName);
+-    void               setProperty(in DOMString propertyName,
+-                                   in DOMString value,
+-                                   in DOMString priority)
+-                                        raises(dom::DOMException);
+-    readonly attribute unsigned long    length;
+-    DOMString          item(in unsigned long index);
+-    readonly attribute CSSRule          parentRule;
+-  };
+-
+-  // Introduced in DOM Level 2:
+-  interface CSSValue {
+-
+-    // UnitTypes
+-    const unsigned short      CSS_INHERIT                    = 0;
+-    const unsigned short      CSS_PRIMITIVE_VALUE            = 1;
+-    const unsigned short      CSS_VALUE_LIST                 = 2;
+-    const unsigned short      CSS_CUSTOM                     = 3;
+-
+-             attribute DOMString        cssText;
+-                                        // raises(dom::DOMException) on setting
+-
+-    readonly attribute unsigned short   cssValueType;
+-  };
+-
+-  // Introduced in DOM Level 2:
+-  interface CSSPrimitiveValue : CSSValue {
+-
+-    // UnitTypes
+-    const unsigned short      CSS_UNKNOWN                    = 0;
+-    const unsigned short      CSS_NUMBER                     = 1;
+-    const unsigned short      CSS_PERCENTAGE                 = 2;
+-    const unsigned short      CSS_EMS                        = 3;
+-    const unsigned short      CSS_EXS                        = 4;
+-    const unsigned short      CSS_PX                         = 5;
+-    const unsigned short      CSS_CM                         = 6;
+-    const unsigned short      CSS_MM                         = 7;
+-    const unsigned short      CSS_IN                         = 8;
+-    const unsigned short      CSS_PT                         = 9;
+-    const unsigned short      CSS_PC                         = 10;
+-    const unsigned short      CSS_DEG                        = 11;
+-    const unsigned short      CSS_RAD                        = 12;
+-    const unsigned short      CSS_GRAD                       = 13;
+-    const unsigned short      CSS_MS                         = 14;
+-    const unsigned short      CSS_S                          = 15;
+-    const unsigned short      CSS_HZ                         = 16;
+-    const unsigned short      CSS_KHZ                        = 17;
+-    const unsigned short      CSS_DIMENSION                  = 18;
+-    const unsigned short      CSS_STRING                     = 19;
+-    const unsigned short      CSS_URI                        = 20;
+-    const unsigned short      CSS_IDENT                      = 21;
+-    const unsigned short      CSS_ATTR                       = 22;
+-    const unsigned short      CSS_COUNTER                    = 23;
+-    const unsigned short      CSS_RECT                       = 24;
+-    const unsigned short      CSS_RGBCOLOR                   = 25;
+-
+-    readonly attribute unsigned short   primitiveType;
+-    void               setFloatValue(in unsigned short unitType,
+-                                     in float floatValue)
+-                                        raises(dom::DOMException);
+-    float              getFloatValue(in unsigned short unitType)
+-                                        raises(dom::DOMException);
+-    void               setStringValue(in unsigned short stringType,
+-                                      in DOMString stringValue)
+-                                        raises(dom::DOMException);
+-    DOMString          getStringValue()
+-                                        raises(dom::DOMException);
+-    Counter            getCounterValue()
+-                                        raises(dom::DOMException);
+-    Rect               getRectValue()
+-                                        raises(dom::DOMException);
+-    RGBColor           getRGBColorValue()
+-                                        raises(dom::DOMException);
+-  };
+-
+-  // Introduced in DOM Level 2:
+-  interface CSSValueList : CSSValue {
+-    readonly attribute unsigned long    length;
+-    CSSValue           item(in unsigned long index);
+-  };
+-
+-  // Introduced in DOM Level 2:
+-  interface RGBColor {
+-    readonly attribute CSSPrimitiveValue  red;
+-    readonly attribute CSSPrimitiveValue  green;
+-    readonly attribute CSSPrimitiveValue  blue;
+-  };
+-
+-  // Introduced in DOM Level 2:
+-  interface Rect {
+-    readonly attribute CSSPrimitiveValue  top;
+-    readonly attribute CSSPrimitiveValue  right;
+-    readonly attribute CSSPrimitiveValue  bottom;
+-    readonly attribute CSSPrimitiveValue  left;
+-  };
+-
+-  // Introduced in DOM Level 2:
+-  interface Counter {
+-    readonly attribute DOMString        identifier;
+-    readonly attribute DOMString        listStyle;
+-    readonly attribute DOMString        separator;
+-  };
+-
+-  // Introduced in DOM Level 2:
+-  interface ElementCSSInlineStyle {
+-    readonly attribute CSSStyleDeclaration  style;
+-  };
+-
+-  // Introduced in DOM Level 2:
+-  interface CSS2Properties {
+-             attribute DOMString        azimuth;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        background;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        backgroundAttachment;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        backgroundColor;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        backgroundImage;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        backgroundPosition;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        backgroundRepeat;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        border;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        borderCollapse;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        borderColor;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        borderSpacing;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        borderStyle;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        borderTop;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        borderRight;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        borderBottom;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        borderLeft;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        borderTopColor;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        borderRightColor;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        borderBottomColor;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        borderLeftColor;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        borderTopStyle;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        borderRightStyle;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        borderBottomStyle;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        borderLeftStyle;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        borderTopWidth;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        borderRightWidth;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        borderBottomWidth;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        borderLeftWidth;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        borderWidth;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        bottom;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        captionSide;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        clear;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        clip;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        color;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        content;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        counterIncrement;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        counterReset;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        cue;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        cueAfter;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        cueBefore;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        cursor;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        direction;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        display;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        elevation;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        emptyCells;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        cssFloat;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        font;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        fontFamily;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        fontSize;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        fontSizeAdjust;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        fontStretch;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        fontStyle;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        fontVariant;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        fontWeight;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        height;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        left;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        letterSpacing;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        lineHeight;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        listStyle;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        listStyleImage;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        listStylePosition;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        listStyleType;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        margin;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        marginTop;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        marginRight;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        marginBottom;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        marginLeft;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        markerOffset;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        marks;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        maxHeight;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        maxWidth;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        minHeight;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        minWidth;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        orphans;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        outline;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        outlineColor;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        outlineStyle;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        outlineWidth;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        overflow;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        padding;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        paddingTop;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        paddingRight;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        paddingBottom;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        paddingLeft;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        page;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        pageBreakAfter;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        pageBreakBefore;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        pageBreakInside;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        pause;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        pauseAfter;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        pauseBefore;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        pitch;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        pitchRange;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        playDuring;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        position;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        quotes;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        richness;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        right;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        size;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        speak;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        speakHeader;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        speakNumeral;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        speakPunctuation;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        speechRate;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        stress;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        tableLayout;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        textAlign;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        textDecoration;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        textIndent;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        textShadow;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        textTransform;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        top;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        unicodeBidi;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        verticalAlign;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        visibility;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        voiceFamily;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        volume;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        whiteSpace;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        widows;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        width;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        wordSpacing;
+-                                        // raises(dom::DOMException) on setting
+-
+-             attribute DOMString        zIndex;
+-                                        // raises(dom::DOMException) on setting
+-
+-  };
+-
+-  // Introduced in DOM Level 2:
+-  interface CSSStyleSheet : stylesheets::StyleSheet {
+-    readonly attribute CSSRule          ownerRule;
+-    readonly attribute CSSRuleList      cssRules;
+-    unsigned long      insertRule(in DOMString rule,
+-                                  in unsigned long index)
+-                                        raises(dom::DOMException);
+-    void               deleteRule(in unsigned long index)
+-                                        raises(dom::DOMException);
+-  };
+-
+-  // Introduced in DOM Level 2:
+-  interface ViewCSS : views::AbstractView {
+-    CSSStyleDeclaration getComputedStyle(in Element elt,
+-                                         in DOMString pseudoElt);
+-  };
+-
+-  // Introduced in DOM Level 2:
+-  interface DocumentCSS : stylesheets::DocumentStyle {
+-    CSSStyleDeclaration getOverrideStyle(in Element elt,
+-                                         in DOMString pseudoElt);
+-  };
+-
+-  // Introduced in DOM   Level 2:
+-  interface DOMImplementationCSS : DOMImplementation {
+-    CSSStyleSheet      createCSSStyleSheet(in DOMString title,
+-                                           in DOMString media)
+-                                        raises(dom::DOMException);
+-  };
+-};
+-
+-#endif // _CSS_IDL_
+-- 
+2.39.0.windows.2
+


### PR DESCRIPTION
Drop IDL extract from DOM-Level-2-Style.

Note CI tests will continue to fail, first because there's a hiccup with the CSS extract due to series shortname being wrong (pending fix in browser-specs), and second because a CSS patch needs to be created for css-color-6.