### PR TITLE
Crawl release versions of specs once per day

### DIFF
--- a/.github/workflows/update-tr.yml
+++ b/.github/workflows/update-tr.yml
@@ -1,6 +1,6 @@
 on:
   schedule:
-    - cron: '0 1 * * 1'
+    - cron: '0 1 * * *'
   workflow_dispatch:
 name: Update TR report
 jobs:


### PR DESCRIPTION
We used to crawl released versions of specs once per week but:
- Definitions are needed for cross-referencing, especially as authoring tools may favor /TR links when preparing /TR versions of specs. Bikeshed typically does that.
- There are more and more specs that get auto-published to /TR whenever the nightly version is updated. Webref may be up to one week late for them, more if weekly crawl crashes for some reason.
- Webref may be up to one week late for new specs as well, as reported in #842. Granted, in a regular course of events, this should not be an issue, as there won't be cross-references to new specs right away.

This update changes the frequency of release crawls to one per day. Nightly versions are crawled 4 times per day but the idea is to err on the conservative side of things to avoid crawling specs too much, in particular those that only have a nightly version and that tend to crash more. In the future, we could perhaps introduce a crawl mode that only considers specs with a release version and either copies extracts from the latest nightly crawl or simply does not produce any info for specs that only have a nightly version.