### PR TITLE
Adjust event name in css-contain-2 patch

### DIFF
--- a/tools/amend-event-data.js
+++ b/tools/amend-event-data.js
@@ -127,9 +127,9 @@ const patches = {
   // tense as part of the resolution)
   'css-contain-2': [
     {
-      pattern: { type: 'contentvisibilityautostatechanged' },
+      pattern: { type: 'contentvisibilityautostatechange' },
       matched: 1,
-      change: { interface: 'ContentVisibilityAutoStateChangedEvent' }
+      change: { interface: 'ContentVisibilityAutoStateChangeEvent' }
     }
   ],
   'css-font-loading-3': [


### PR DESCRIPTION
Group switched to using a present form. They still have not improved the phrasing though.

CI tests will continue to fail for unrelated reasons (should be fixed with next crawl)