### PR TITLE
Add event patch for WebTransport

### DIFF
--- a/tools/amend-event-data.js
+++ b/tools/amend-event-data.js
@@ -498,6 +498,14 @@ const patches = {
       change: { interface: "MIDIMessageEvent" }
     }
   ],
+  // pending https://github.com/w3c/webtransport/pull/473
+  'webtransport': [
+    {
+      pattern: { type: "ratecontrolfeedback" },
+      matched: 1,
+      change: { interface: "Event" }
+    }
+  ],
   // pending https://github.com/immersive-web/layers/pull/285
   'webxrlayers-1': [
     {


### PR DESCRIPTION
Patch to be kept until related PR is merged:
https://github.com/w3c/webtransport/pull/473