### PR TITLE
Rename "prepare" script to "curate" to prevent auto-runs

### DIFF
--- a/.github/workflows/curate.yml
+++ b/.github/workflows/curate.yml
@@ -34,9 +34,11 @@ jobs:
         # the curated branch
         fetch-depth: 0
 
-    - name: Prepare curated and packages data
-      # Note that "ci" runs the "prepare" script
+    - name: Install dependencies
       run: npm ci
+
+    - name: Prepare curated and packages data
+      run: npm run curate
 
     - name: Test curated and packages data
       run: npm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,11 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: '14'
-    - run: npm ci
-    - run: npm test
+    - name: Install dependencies
+      run: npm ci
+    - name: Prepare curated and packages data
+      run: npm run curate
+    - name: Test curated and packages data
+      run: npm test
 env:
   FORCE_COLOR: 3

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "scripts": {
     "create-patch": "node tools/create-patch.js",
-    "prepare": "node tools/prepare-curated.js ed curated && node tools/prepare-packages.js curated packages",
+    "curate": "node tools/prepare-curated.js ed curated && node tools/prepare-packages.js curated packages",
     "test": "mocha --recursive",
     "test-css": "mocha --recursive test/css",
     "test-elements": "mocha --recursive test/elements",


### PR DESCRIPTION
The `prepare` script is run automatically when the repository is installed. On top of creating issues when the repository is set as dependency in another project for some reason, as described in https://github.com/w3c/webref/issues/789#issuecomment-1464094879, this also seems wrong because:
1. There is no guarantee that the curation will run without errors. A patch may no longer apply for instance. This means that `npm install github:w3c/webref` may fail from time to time.
2. Projects may want to depend on the raw data and may not need to run the curation and package preparation logic at all.

This update replaces the "prepare" script with a "curate" one, explicitly called by the jobs that need it.

I don't know if other projects depend on the `w3c/webref` repository directly. If they do and need to access curated data, they would need to update to call `npm run curate` explicitly.