### PR TITLE
Release script: Make explicit call to "curate"

### DIFF
--- a/tools/release-package.js
+++ b/tools/release-package.js
@@ -81,6 +81,9 @@ async function releasePackage(prNumber) {
     execSync("npm ci", {
       cwd: installFolder
     });
+    execSync("npm run curate", {
+      cwd: installFolder
+    });
 
     console.log(`- Publish packages/${type} folder to npm`);
     const packageFolder = path.join(installFolder, "packages", type, "package.json");


### PR DESCRIPTION
The release script installs the repository from the data on the `main` branch. Previous call to `npm ci` implicitly ran the `prepare` script. The new `curate` script that replaces `prepare` now needs to be called explicitly.