### PR TITLE
Jobs: Bump Node.js version to v18

### DIFF
--- a/.github/workflows/clean-patches.yml
+++ b/.github/workflows/clean-patches.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@v2
       with:
-        node-version: '14'
+        node-version: 18
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@v2
       with:
-        node-version: '14'
+        node-version: 18
     - name: Run clean up
       run: node tools/clean-abandoned-files.js
     - uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/curate.yml
+++ b/.github/workflows/curate.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@v2
       with:
-        node-version: '16'
+        node-version: 18
 
     - name: Checkout webref
       uses: actions/checkout@v2

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@v2
       with:
-        node-version: '14'
+        node-version: 18
 
     - name: Checkout latest version of release script
       uses: actions/checkout@v2

--- a/.github/workflows/request-pr-review.yml
+++ b/.github/workflows/request-pr-review.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@v2
       with:
-        node-version: '14'
+        node-version: 18
 
     - name: Checkout webref
       uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: '14'
+        node-version: 18
     - name: Install dependencies
       run: npm ci
     - name: Prepare curated and packages data

--- a/.github/workflows/update-ed.yml
+++ b/.github/workflows/update-ed.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@v2
       with:
-        node-version: 14
+        node-version: 18
 
     # Temp (2023-01-07): Force version of node-fetch, pending resolution of:
     # https://github.com/node-fetch/node-fetch/issues/1701

--- a/.github/workflows/update-tr.yml
+++ b/.github/workflows/update-tr.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@v2
       with:
-        node-version: 14
+        node-version: 18
 
     - name: Install reffy
       run: npm install reffy

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=18"
   },
   "devDependencies": {
     "@actions/core": "1.10.0",


### PR DESCRIPTION
Jobs were using a mix of v14 and v16, while `package.json` advertized that v10 was all good. Update switches everything to v18.

This is in preparation for #952 since Reffy v13 requires Node.js v18 (at least in theory).