### PR TITLE
Adjust reference to npm-publish

### DIFF
--- a/tools/release-package.js
+++ b/tools/release-package.js
@@ -9,7 +9,7 @@ const path = require("path");
 const os = require("os");
 const { execSync } = require("child_process");
 const { rimraf } = require("rimraf");
-const npmPublish = require("@jsdevtools/npm-publish");
+const { npmPublish } = require("@jsdevtools/npm-publish");
 
 const owner = "w3c";
 const repo = "webref";


### PR DESCRIPTION
Not advertized in the list of breaking changes made in v2 AFAICT, but main function is no longer exported as default.

Note: Latest version of NPM packages could not be published as a result, I'll try to do that manually.