### PR TITLE
Delegate Web IDL consistency tests to Strudy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "mocha": "10.2.0",
         "reffy": "13.0.0",
         "rimraf": "5.0.1",
+        "strudy": "^2.0.0",
         "webidl2": "24.3.0"
       },
       "engines": {
@@ -650,6 +651,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@types/node": {
       "version": "18.16.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.0.tgz",
@@ -1210,6 +1220,31 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -1493,6 +1528,43 @@
         "node": ">= 6"
       }
     },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "dev": true,
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1509,6 +1581,20 @@
       "dev": true,
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -1604,6 +1690,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-extglob": {
@@ -1728,6 +1823,15 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -1958,6 +2062,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/node-pandoc": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/node-pandoc/-/node-pandoc-0.3.0.tgz",
+      "integrity": "sha512-e+kANHQQFBlN7J8wEFf7sNc1sSCLltyPtPqNA/IEapiNsA1LjZ9mtV/B0lU6b2cAdvn7rrAVNBONw+Fo1YsY+A==",
+      "dev": true
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -2379,6 +2489,19 @@
         }
       ]
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "dev": true,
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/semver": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
@@ -2445,6 +2568,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -2508,6 +2637,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -2539,6 +2677,246 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/strudy": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strudy/-/strudy-2.0.0.tgz",
+      "integrity": "sha512-gDw5c1SvhI1Y5+8lNcyAv2FsGrIqTa2s5aC3p49/BvT84tc7TgfaBvCW9bC/A6vzOFi0keF4/CxVq1WLLsq8Ig==",
+      "dev": true,
+      "dependencies": {
+        "@actions/core": "^1.10.0",
+        "@octokit/plugin-throttling": "^6.0.0",
+        "@octokit/rest": "^19.0.4",
+        "commander": "10.0.1",
+        "gray-matter": "^4.0.3",
+        "node-fetch": "^2.6.5",
+        "node-pandoc": "0.3.0",
+        "reffy": "^13.0.3",
+        "semver": "^7.3.5",
+        "webidl2": "^24.2.2"
+      },
+      "bin": {
+        "strudy": "strudy.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/strudy/node_modules/@octokit/openapi-types": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-17.2.0.tgz",
+      "integrity": "sha512-MazrFNx4plbLsGl+LFesMo96eIXkFgEtaKbnNpdh4aQ0VM10aoylFsTYP1AEjkeoRNZiiPe3T6Gl2Hr8dJWdlQ==",
+      "dev": true
+    },
+    "node_modules/strudy/node_modules/@octokit/plugin-throttling": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-6.0.0.tgz",
+      "integrity": "sha512-RdKkzD8X/T17KJmEHTsZ5Ztj7WGNpxsJAIyR1bgvkoyar+cDrIRZMsP15r8JRB1QI/LN2F/stUs5/kMVaYXS9g==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/types": "^9.0.0",
+        "bottleneck": "^2.15.3"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "^4.0.0"
+      }
+    },
+    "node_modules/strudy/node_modules/@octokit/types": {
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.2.3.tgz",
+      "integrity": "sha512-MMeLdHyFIALioycq+LFcA71v0S2xpQUX2cw6pPbHQjaibcHYwLnmK/kMZaWuGfGfjBJZ3wRUq+dOaWsvrPJVvA==",
+      "dev": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^17.2.0"
+      }
+    },
+    "node_modules/strudy/node_modules/@puppeteer/browsers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.3.0.tgz",
+      "integrity": "sha512-an3QdbNPkuU6qpxpbssxAbjRLJcF+eP4L8UqIY3+6n0sbaVxw5pz7PiCLy9g32XEZuoamUlV5ZQPnA6FxvkIHA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4.3.4",
+        "extract-zip": "2.0.1",
+        "http-proxy-agent": "5.0.0",
+        "https-proxy-agent": "5.0.1",
+        "progress": "2.0.3",
+        "proxy-from-env": "1.1.0",
+        "tar-fs": "2.1.1",
+        "unbzip2-stream": "1.4.3",
+        "yargs": "17.7.1"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.7.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/strudy/node_modules/chromium-bidi": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.9.tgz",
+      "integrity": "sha512-u3DC6XwgLCA9QJ5ak1voPslCmacQdulZNCPsI3qNXxSnEcZS7DFIbww+5RM2bznMEje7cc0oydavRLRvOIZtHw==",
+      "dev": true,
+      "dependencies": {
+        "mitt": "3.0.0"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/strudy/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/strudy/node_modules/cross-fetch": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.6.tgz",
+      "integrity": "sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==",
+      "dev": true,
+      "dependencies": {
+        "node-fetch": "^2.6.11"
+      }
+    },
+    "node_modules/strudy/node_modules/devtools-protocol": {
+      "version": "0.0.1120988",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1120988.tgz",
+      "integrity": "sha512-39fCpE3Z78IaIPChJsP6Lhmkbf4dWXOmzLk/KFTdRkNk/0JymRIfUynDVRndV9HoDz8PyalK1UH21ST/ivwW5Q==",
+      "dev": true
+    },
+    "node_modules/strudy/node_modules/node-fetch": {
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/strudy/node_modules/puppeteer": {
+      "version": "20.3.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-20.3.0.tgz",
+      "integrity": "sha512-OJIsxC3PcU6fAWfp1BX0oKj62FFxhxwpakGAcGVbyfqfDrNmkFjpzb0XrMsgnQxCJmoLpTZKHRXDFxEDnLqkow==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@puppeteer/browsers": "1.3.0",
+        "cosmiconfig": "8.1.3",
+        "puppeteer-core": "20.3.0"
+      }
+    },
+    "node_modules/strudy/node_modules/puppeteer-core": {
+      "version": "20.3.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.3.0.tgz",
+      "integrity": "sha512-264pBrIui5bO6NJeOcbJrLa0OCwmA4+WK00JMrLIKTfRiqe2gx8KWTzLsjyw/bizErp3TKS7vt/I0i5fTC+mAw==",
+      "dev": true,
+      "dependencies": {
+        "@puppeteer/browsers": "1.3.0",
+        "chromium-bidi": "0.4.9",
+        "cross-fetch": "3.1.6",
+        "debug": "4.3.4",
+        "devtools-protocol": "0.0.1120988",
+        "ws": "8.13.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.7.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/strudy/node_modules/reffy": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/reffy/-/reffy-13.0.3.tgz",
+      "integrity": "sha512-BJ86IUF+DmruQgfMSvu0yPzXxnnV9htGAI3ck2DnyT/eFyuf/XJmVktuFltsHXKj7hwqAiKbLBN6WmRDRaKRSg==",
+      "dev": true,
+      "dependencies": {
+        "abortcontroller-polyfill": "1.7.5",
+        "ajv": "8.12.0",
+        "ajv-formats": "2.1.1",
+        "commander": "10.0.1",
+        "fetch-filecache-for-crawling": "4.1.0",
+        "puppeteer": "20.3.0",
+        "semver": "^7.3.5",
+        "web-specs": "2.59.0",
+        "webidl2": "24.3.0"
+      },
+      "bin": {
+        "reffy": "reffy.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/strudy/node_modules/web-specs": {
+      "version": "2.59.0",
+      "resolved": "https://registry.npmjs.org/web-specs/-/web-specs-2.59.0.tgz",
+      "integrity": "sha512-948poJr8AuAbLHENk1Ilvg9Kgb0LVLglKRgMVGvQqtO6ocNGi5yU50YggZl0THTDO0BvcFsXar/WCv43PUmXaQ==",
+      "dev": true
+    },
+    "node_modules/strudy/node_modules/yargs": {
+      "version": "17.7.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/strudy/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/supports-color": {
@@ -2966,7 +3344,7 @@
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "webidl2": "^24.2.2"
+        "webidl2": "^24.3.0"
       }
     }
   },
@@ -3485,6 +3863,12 @@
         }
       }
     },
+    "@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "dev": true
+    },
     "@types/node": {
       "version": "18.16.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.0.tgz",
@@ -3910,6 +4294,21 @@
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true
     },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "dev": true,
+      "requires": {
+        "is-extendable": "^0.1.0"
+      }
+    },
     "extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -4113,6 +4512,39 @@
         "is-glob": "^4.0.1"
       }
     },
+    "gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "dev": true,
+      "requires": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        }
+      }
+    },
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -4124,6 +4556,17 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
+    },
+    "http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "requires": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      }
     },
     "https-proxy-agent": {
       "version": "5.0.1",
@@ -4190,6 +4633,12 @@
       "requires": {
         "binary-extensions": "^2.0.0"
       }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "dev": true
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -4277,6 +4726,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
     "lines-and-columns": {
@@ -4448,6 +4903,12 @@
       "requires": {
         "whatwg-url": "^5.0.0"
       }
+    },
+    "node-pandoc": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/node-pandoc/-/node-pandoc-0.3.0.tgz",
+      "integrity": "sha512-e+kANHQQFBlN7J8wEFf7sNc1sSCLltyPtPqNA/IEapiNsA1LjZ9mtV/B0lU6b2cAdvn7rrAVNBONw+Fo1YsY+A==",
+      "dev": true
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -4744,6 +5205,16 @@
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true
     },
+    "section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      }
+    },
     "semver": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
@@ -4787,6 +5258,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.1.tgz",
       "integrity": "sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA==",
+      "dev": true
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
     "string_decoder": {
@@ -4838,6 +5315,12 @@
         "ansi-regex": "^5.0.1"
       }
     },
+    "strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "dev": true
+    },
     "strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -4857,6 +5340,181 @@
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
           "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        }
+      }
+    },
+    "strudy": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strudy/-/strudy-2.0.0.tgz",
+      "integrity": "sha512-gDw5c1SvhI1Y5+8lNcyAv2FsGrIqTa2s5aC3p49/BvT84tc7TgfaBvCW9bC/A6vzOFi0keF4/CxVq1WLLsq8Ig==",
+      "dev": true,
+      "requires": {
+        "@actions/core": "^1.10.0",
+        "@octokit/plugin-throttling": "^6.0.0",
+        "@octokit/rest": "^19.0.4",
+        "commander": "10.0.1",
+        "gray-matter": "^4.0.3",
+        "node-fetch": "^2.6.5",
+        "node-pandoc": "0.3.0",
+        "reffy": "^13.0.3",
+        "semver": "^7.3.5",
+        "webidl2": "^24.2.2"
+      },
+      "dependencies": {
+        "@octokit/openapi-types": {
+          "version": "17.2.0",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-17.2.0.tgz",
+          "integrity": "sha512-MazrFNx4plbLsGl+LFesMo96eIXkFgEtaKbnNpdh4aQ0VM10aoylFsTYP1AEjkeoRNZiiPe3T6Gl2Hr8dJWdlQ==",
+          "dev": true
+        },
+        "@octokit/plugin-throttling": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-6.0.0.tgz",
+          "integrity": "sha512-RdKkzD8X/T17KJmEHTsZ5Ztj7WGNpxsJAIyR1bgvkoyar+cDrIRZMsP15r8JRB1QI/LN2F/stUs5/kMVaYXS9g==",
+          "dev": true,
+          "requires": {
+            "@octokit/types": "^9.0.0",
+            "bottleneck": "^2.15.3"
+          }
+        },
+        "@octokit/types": {
+          "version": "9.2.3",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.2.3.tgz",
+          "integrity": "sha512-MMeLdHyFIALioycq+LFcA71v0S2xpQUX2cw6pPbHQjaibcHYwLnmK/kMZaWuGfGfjBJZ3wRUq+dOaWsvrPJVvA==",
+          "dev": true,
+          "requires": {
+            "@octokit/openapi-types": "^17.2.0"
+          }
+        },
+        "@puppeteer/browsers": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.3.0.tgz",
+          "integrity": "sha512-an3QdbNPkuU6qpxpbssxAbjRLJcF+eP4L8UqIY3+6n0sbaVxw5pz7PiCLy9g32XEZuoamUlV5ZQPnA6FxvkIHA==",
+          "dev": true,
+          "requires": {
+            "debug": "4.3.4",
+            "extract-zip": "2.0.1",
+            "http-proxy-agent": "5.0.0",
+            "https-proxy-agent": "5.0.1",
+            "progress": "2.0.3",
+            "proxy-from-env": "1.1.0",
+            "tar-fs": "2.1.1",
+            "unbzip2-stream": "1.4.3",
+            "yargs": "17.7.1"
+          }
+        },
+        "chromium-bidi": {
+          "version": "0.4.9",
+          "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.9.tgz",
+          "integrity": "sha512-u3DC6XwgLCA9QJ5ak1voPslCmacQdulZNCPsI3qNXxSnEcZS7DFIbww+5RM2bznMEje7cc0oydavRLRvOIZtHw==",
+          "dev": true,
+          "requires": {
+            "mitt": "3.0.0"
+          }
+        },
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "cross-fetch": {
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.6.tgz",
+          "integrity": "sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==",
+          "dev": true,
+          "requires": {
+            "node-fetch": "^2.6.11"
+          }
+        },
+        "devtools-protocol": {
+          "version": "0.0.1120988",
+          "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1120988.tgz",
+          "integrity": "sha512-39fCpE3Z78IaIPChJsP6Lhmkbf4dWXOmzLk/KFTdRkNk/0JymRIfUynDVRndV9HoDz8PyalK1UH21ST/ivwW5Q==",
+          "dev": true
+        },
+        "node-fetch": {
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
+          "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
+          "dev": true,
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "puppeteer": {
+          "version": "20.3.0",
+          "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-20.3.0.tgz",
+          "integrity": "sha512-OJIsxC3PcU6fAWfp1BX0oKj62FFxhxwpakGAcGVbyfqfDrNmkFjpzb0XrMsgnQxCJmoLpTZKHRXDFxEDnLqkow==",
+          "dev": true,
+          "requires": {
+            "@puppeteer/browsers": "1.3.0",
+            "cosmiconfig": "8.1.3",
+            "puppeteer-core": "20.3.0"
+          }
+        },
+        "puppeteer-core": {
+          "version": "20.3.0",
+          "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.3.0.tgz",
+          "integrity": "sha512-264pBrIui5bO6NJeOcbJrLa0OCwmA4+WK00JMrLIKTfRiqe2gx8KWTzLsjyw/bizErp3TKS7vt/I0i5fTC+mAw==",
+          "dev": true,
+          "requires": {
+            "@puppeteer/browsers": "1.3.0",
+            "chromium-bidi": "0.4.9",
+            "cross-fetch": "3.1.6",
+            "debug": "4.3.4",
+            "devtools-protocol": "0.0.1120988",
+            "ws": "8.13.0"
+          }
+        },
+        "reffy": {
+          "version": "13.0.3",
+          "resolved": "https://registry.npmjs.org/reffy/-/reffy-13.0.3.tgz",
+          "integrity": "sha512-BJ86IUF+DmruQgfMSvu0yPzXxnnV9htGAI3ck2DnyT/eFyuf/XJmVktuFltsHXKj7hwqAiKbLBN6WmRDRaKRSg==",
+          "dev": true,
+          "requires": {
+            "abortcontroller-polyfill": "1.7.5",
+            "ajv": "8.12.0",
+            "ajv-formats": "2.1.1",
+            "commander": "10.0.1",
+            "fetch-filecache-for-crawling": "4.1.0",
+            "puppeteer": "20.3.0",
+            "semver": "^7.3.5",
+            "web-specs": "2.59.0",
+            "webidl2": "24.3.0"
+          }
+        },
+        "web-specs": {
+          "version": "2.59.0",
+          "resolved": "https://registry.npmjs.org/web-specs/-/web-specs-2.59.0.tgz",
+          "integrity": "sha512-948poJr8AuAbLHENk1Ilvg9Kgb0LVLglKRgMVGvQqtO6ocNGi5yU50YggZl0THTDO0BvcFsXar/WCv43PUmXaQ==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "17.7.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+          "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^8.0.1",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "mocha": "10.2.0",
     "reffy": "13.0.0",
     "rimraf": "5.0.1",
+    "strudy": "^2.0.0",
     "webidl2": "24.3.0"
   },
   "scripts": {

--- a/test/idl/consistency.js
+++ b/test/idl/consistency.js
@@ -10,10 +10,10 @@
  * view because of some missing IDL definition in that view.
  */
 
-
 const assert = require('assert').strict;
 const path = require('path');
 const idl = require('@webref/idl');
+const { studyWebIdl } = require('strudy');
 
 const views = [
   {
@@ -26,429 +26,56 @@ const views = [
   }
 ];
 
-// Helper to get a map of unique definitions in |dfns|, for convenience and to
-// avoid O(n^2) in the common `for (dfn of dfns) { dfns.find(...) }`.
-function nameMap(dfns) {
-  assert(Array.isArray(dfns));
+// These anomalies are not currently enforced
+const ignorableAnomalies = [
+  'singleEnumValue',
+  'wrongCaseEnumValue'
+];
 
-  const map = new Map();
-  for (const dfn of dfns) {
-    assert(!map.has(dfn.name), `duplicate definition of ${dfn.name}`);
-    map.set(dfn.name, dfn);
+
+function writeAnomalies(report) {
+  function writeAnomaly(anomaly) {
+    return `- ${anomaly.name} in ${anomaly.specs.map(s => s.shortname).join(', ')}: ${anomaly.message}`;
   }
-  return map;
+
+  return 'Web IDL anomalies found:\n' +
+    report.map(writeAnomaly).join('\n');
 }
-
-function getExtAttr(node, name) {
-  return node.extAttrs && node.extAttrs.find((attr) => attr.name === name);
-}
-
-// Helper to test if two members define the same thing, such as the same
-// attribute or the same method. Should match requirements in spec:
-// https://heycam.github.io/webidl/#idl-overloading
-function isOverloadedOperation(a, b) {
-  if (a.type !== 'constructor' && a.type !== 'operation') {
-    return false;
-  }
-  if (a.type !== b.type) {
-    return false;
-  }
-  // Note that |name| or |special| could be null/undefined, but even then
-  // they have to be the same for both members.
-  if (a.name !== b.name) {
-    return false;
-  }
-  if (a.special !== b.special) {
-    return false;
-  }
-  return true;
-}
-
-// Helper to test if two members define an operation with the same identifier,
-// one of them being a static operation and the other a regular one. This is
-// allowed in Web IDL, see https://github.com/whatwg/webidl/issues/1097
-function isAllowedOperationWithSameIdentifier(a, b) {
-  if (a.type !== 'operation') {
-    return false;
-  }
-  if (a.type !== b.type) {
-    return false;
-  }
-  if (a.name !== b.name) {
-    return false;
-  }
-  if (a.special !== 'static' && b.special !== 'static') {
-    return false;
-  }
-  if (a.special === b.special) {
-    return false;
-  }
-  return true;
-}
-
-function describeDfn(dfn) {
-  let desc = dfn.type;
-  if (dfn.name) {
-    desc += ' ' + dfn.name;
-  }
-  if (dfn.partial) {
-    desc = 'partial ' + desc;
-  }
-  return desc;
-}
-
-function describeMember(member) {
-  let desc = member.type;
-  if (member.name) {
-    desc += ' ' + member.name;
-  }
-  if (member.special) {
-    desc = member.special + ' ' + desc;
-  }
-  return desc;
-}
-
-function mergeMembers(target, source) {
-  // Check for overloaded operation across partials/mixins. This is O(n^2) and
-  // could be improved, but it's fast enough (and simple) for testing.
-  for (const targetMember of target.members) {
-    for (const sourceMember of source.members) {
-      assert(!isOverloadedOperation(targetMember, sourceMember),
-          `invalid overload of ${describeMember(targetMember)} from ${describeDfn(source)}`);
-    }
-  }
-  // Now merge members.
-  target.members.push(...source.members);
-}
-
-// This could be useful part of the public API, but for now just run the
-// merging in order to find problems. Modifies some definitions in place,
-// and returns a list of only the merged definitions.
-function merge(dfns, partials, includes) {
-  assert(Array.isArray(dfns));
-  assert(Array.isArray(partials));
-  assert(Array.isArray(includes));
-
-  dfns = nameMap(dfns); // replace |dfns| to avoid using it
-
-  // merge partials (including partial mixins)
-  for (const partial of partials) {
-    const target = dfns.get(partial.name);
-    assert(target, `target definition of partial ${partial.type} ${partial.name} not found`);
-    assert.equal(partial.type, target.type, `${partial.name} inherits from wrong type: ${target.type}`);
-    // TODO: account for extended attributes on the partial definition
-    mergeMembers(target, partial);
-  }
-
-  // mix in the mixins
-  for (const include of includes) {
-    assert(include.target);
-    const target = dfns.get(include.target);
-    assert(target, `missing target of includes statement: ${include.target}`);
-    assert.equal(target.type, 'interface');
-
-    assert(include.includes);
-    const mixin = dfns.get(include.includes);
-    assert(mixin, `missing source of includes statement: ${include.includes}`);
-    assert.equal(mixin.type, 'interface mixin');
-
-    mergeMembers(target, mixin);
-  }
-
-  // remove all mixins, whether used or not
-  for (const [name, dfn] of dfns) {
-    if (dfn.type === 'interface mixin') {
-      dfns.delete(name);
-    }
-  }
-
-  // now check for duplicate members
-  for (const dfn of dfns.values()) {
-    if (!dfn.members) {
-      continue;
-    }
-    const namedMembers = new Map();
-    for (const member of dfn.members) {
-      if (!member.name) {
-        continue;
-      }
-      const firstMember = namedMembers.get(member.name);
-      if (firstMember) {
-        // Overloaded operations are OK.
-        if (isOverloadedOperation(member, firstMember)) {
-          continue;
-        }
-        // Non-overlapping exposure sets are OK. Assume it's OK if either
-        // members has an [Exposed] extended attribute. TODO: do better.
-        if (getExtAttr(firstMember, 'Exposed') || getExtAttr(member, 'Exposed')) {
-          continue;
-        }
-        // A static operation that has the same identifier as a regular one is OK
-        if (isAllowedOperationWithSameIdentifier(member, firstMember)) {
-          continue;
-        }
-        assert.fail(`duplicate definition of ${dfn.name} member ${member.name}`);
-      } else {
-        namedMembers.set(member.name, member);
-      }
-    }
-  }
-
-  // finally return a sorted list of merged definitions
-  return Array.from(dfns.values());
-}
-
 
 views.forEach(({ name, folder }) => {
   describe(`The ${name} view of Web IDL extracts`, () => {
-    const dfns = [];
-    const includes = [];
-    const partials = [];
+    it('passes Strudy\'s scrutiny', async function () {
+      const all = await idl.listAll({ folder });
+      const crawl = [];
+      for (const [shortname, value] of Object.entries(all)) {
+        crawl.push({ shortname, idl: await value.text() });
+      }
+      const report = studyWebIdl(crawl, [])
+        .filter(anomaly => !ignorableAnomalies.includes(anomaly.name))
+        .filter(anomaly => {
+          // Filter out a couple of known anomalies triggered by specs extending
+          // base interfaces and adding new features that require changes to the
+          // base interfaces themselves
 
-    before(async () => {
-      const all = await idl.parseAll({ folder });
-
-      for (const [spec, ast] of Object.entries(all)) {
-        for (const dfn of ast) {
-          if (dfn.partial) {
-            partials.push(dfn);
-          } else if (dfn.type === 'includes') {
-            includes.push(dfn);
-          } else if (dfn.name) {
-            dfns.push(dfn);
-          } else {
-            assert.fail(`unknown definition in ${spec}: ${JSON.stringify(dfn)}`);
+          // Known anomaly, tracked in:
+          // https://github.com/w3c/media-source/issues/280
+          if (anomaly.name === 'unexpectedEventHandler' &&
+              anomaly.specs[0].shortname === 'window-management' &&
+              anomaly.message === 'The interface "Screen" defines an event handler "onchange" but does not inherit from EventTarget') {
+            return false;
           }
-        }
-      }
-    });
 
-    it('contains IDL names linked to only one "dfn"', function () {
-      assert.equal(nameMap(dfns).size, dfns.length);
-    });
-
-    it('contains IDL names that inherit from known types', function () {
-      const map = nameMap(dfns);
-      for (const dfn of map.values()) {
-        if (dfn.inheritance) {
-          const parent = map.get(dfn.inheritance);
-          assert(parent, `${dfn.name} inherits from missing type: ${dfn.inheritance}`);
-          assert.equal(dfn.type, parent.type, `${dfn.name} inherits from wrong type: ${parent.type}`);
-        }
-      }
-    });
-
-    // Validate that there are no unknown types or extended attributes.
-    it('uses only known types and extended attributes', function () {
-      this.slow(2000);
-      // There are types in lots of places in the AST (interface members,
-      // arguments, return types) and rather than trying to cover them all, walk
-      // the whole AST looking for "idlType".
-      const usedTypes = new Set();
-      const usedExtAttrs = new Set();
-
-      // Serialize and reparse the ast to not have to worry about own properties
-      // vs enumerable properties on the prototypes, etc.
-      const pending = [JSON.parse(JSON.stringify([...dfns, ...partials]))];
-      while (pending.length) {
-        const node = pending.pop();
-        for (const [key, value] of Object.entries(node)) {
-          if (key === 'idlType' && typeof value === 'string') {
-            usedTypes.add(value);
-          } else if (key === 'extAttrs' && Array.isArray(value)) {
-            for (const extAttr of value) {
-              usedExtAttrs.add(extAttr.name);
-            }
-          } else if (typeof value === 'object' && value !== null) {
-            pending.push(value);
+          // Known anomalies, noted in:
+          // https://w3c.github.io/window-management/#api-extensions-to-screen
+          if (anomaly.name === 'incompatiblePartialIdlExposure' &&
+              anomaly.specs[0].shortname === 'media-source' &&
+              anomaly.message.startsWith('The [Exposed] extended attribute of the partial interface')) {
+            return false;
           }
-        }
-      }
 
-      const knownTypes = new Set([
-        // Types defined by Web IDL itself:
-        'any', // https://heycam.github.io/webidl/#idl-any
-        'ArrayBuffer', // https://heycam.github.io/webidl/#idl-ArrayBuffer
-        'bigint', // https://heycam.github.io/webidl/#idl-bigint
-        'boolean', // https://heycam.github.io/webidl/#idl-boolean
-        'byte', // https://heycam.github.io/webidl/#idl-byte
-        'ByteString', // https://heycam.github.io/webidl/#idl-ByteString
-        'DataView', // https://heycam.github.io/webidl/#idl-DataView
-        'DOMString', // https://heycam.github.io/webidl/#idl-DOMString
-        'double', // https://heycam.github.io/webidl/#idl-double
-        'float', // https://heycam.github.io/webidl/#idl-float
-        'Float32Array', // https://heycam.github.io/webidl/#idl-Float32Array
-        'Float64Array', // https://heycam.github.io/webidl/#idl-Float64Array
-        'Int16Array', // https://heycam.github.io/webidl/#idl-Int16Array
-        'Int32Array', // https://heycam.github.io/webidl/#idl-Int32Array
-        'Int8Array', // https://heycam.github.io/webidl/#idl-Int8Array
-        'long long', // https://heycam.github.io/webidl/#idl-long-long
-        'long', // https://heycam.github.io/webidl/#idl-long
-        'object', // https://heycam.github.io/webidl/#idl-object
-        'octet', // https://heycam.github.io/webidl/#idl-octet
-        'short', // https://heycam.github.io/webidl/#idl-short
-        'symbol', // https://heycam.github.io/webidl/#idl-symbol
-        'BigUint64Array', // https://heycam.github.io/webidl/#idl-BigUint64Array
-        'BigInt64Array', // https://heycam.github.io/webidl/#idl-BigInt64Array
-        'Uint16Array', // https://heycam.github.io/webidl/#idl-Uint16Array
-        'Uint32Array', // https://heycam.github.io/webidl/#idl-Uint32Array
-        'Uint8Array', // https://heycam.github.io/webidl/#idl-Uint8Array
-        'Uint8ClampedArray', // https://heycam.github.io/webidl/#idl-Uint8ClampedArray
-        'unrestricted double', // https://heycam.github.io/webidl/#idl-unrestricted-double
-        'unrestricted float', // https://heycam.github.io/webidl/#idl-unrestricted-float
-        'unsigned long long', // https://heycam.github.io/webidl/#idl-unsigned-long-long
-        'unsigned long', // https://heycam.github.io/webidl/#idl-unsigned-long
-        'unsigned short', // https://heycam.github.io/webidl/#idl-unsigned-short
-        'USVString', // https://heycam.github.io/webidl/#idl-USVString
-        'undefined', // https://heycam.github.io/webidl/#idl-undefined
-
-        // Types defined by other specs:
-        'CSSOMString', // https://drafts.csswg.org/cssom/#cssomstring-type
-        'WindowProxy' // https://html.spec.whatwg.org/multipage/window-object.html#windowproxy
-      ]);
-
-      const knownExtAttrs = new Set([
-        // Extended attributes defined by Web IDL itself:
-        'AllowShared', // https://heycam.github.io/webidl/#AllowShared
-        'Clamp', // https://heycam.github.io/webidl/#Clamp
-        'CrossOriginIsolated', // https://heycam.github.io/webidl/#CrossOriginIsolated
-        'Default', // https://heycam.github.io/webidl/#Default
-        'EnforceRange', // https://heycam.github.io/webidl/#EnforceRange
-        'Exposed', // https://heycam.github.io/webidl/#Exposed
-        'Global', // https://heycam.github.io/webidl/#Global
-        'LegacyFactoryFunction', // https://heycam.github.io/webidl/#LegacyFactoryFunction
-        'LegacyLenientSetter', // https://heycam.github.io/webidl/#LegacyLenientSetter
-        'LegacyLenientThis', // https://heycam.github.io/webidl/#LegacyLenientThis
-        'LegacyNamespace', // https://heycam.github.io/webidl/#LegacyNamespace
-        'LegacyNoInterfaceObject', // https://heycam.github.io/webidl/#LegacyNoInterfaceObject
-        'LegacyNullToEmptyString', // https://heycam.github.io/webidl/#LegacyNullToEmptyString
-        'LegacyOverrideBuiltIns', // https://heycam.github.io/webidl/#LegacyOverrideBuiltIns
-        'LegacyTreatNonObjectAsNull', // https://heycam.github.io/webidl/#LegacyTreatNonObjectAsNull
-        'LegacyUnenumerableNamedProperties', // https://heycam.github.io/webidl/#LegacyUnenumerableNamedProperties
-        'LegacyUnforgeable', // https://heycam.github.io/webidl/#LegacyUnforgeable
-        'LegacyWindowAlias', // https://heycam.github.io/webidl/#LegacyWindowAlias
-        'NewObject', // https://heycam.github.io/webidl/#NewObject
-        'PutForwards', // https://heycam.github.io/webidl/#PutForwards
-        'Replaceable', // https://heycam.github.io/webidl/#Replaceable
-        'SameObject', // https://heycam.github.io/webidl/#SameObject
-        'SecureContext', // https://heycam.github.io/webidl/#SecureContext
-        'Unscopable', // https://heycam.github.io/webidl/#Unscopable
-
-        // Extended attributes defined by other specs:
-        'CEReactions', // https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions
-        'HTMLConstructor', // https://html.spec.whatwg.org/multipage/dom.html#htmlconstructor
-        'Serializable', // https://html.spec.whatwg.org/multipage/structured-data.html#serializable
-        'StringContext', // https://w3c.github.io/webappsec-trusted-types/dist/spec/#webidl-string-context-xattr
-        'Transferable', // https://html.spec.whatwg.org/multipage/structured-data.html#transferable
-        'WebGLHandlesContextLoss' // https://registry.khronos.org/webgl/specs/latest/1.0/##5.14
-      ]);
-
-      // Add any types defined by the parsed IDL, while also forbidding some that
-      // can be used mistakenly. Should match https://heycam.github.io/webidl/#idl-types.
-      const knownInvalidTypes = new Map();
-      for (const dfn of dfns) {
-        if (dfn.type === 'interface mixin' || dfn.type === 'namespace') {
-          knownInvalidTypes.set(dfn.name, dfn.type);
-        } else {
-          knownTypes.add(dfn.name);
-        }
-      }
-
-      for (const usedType of usedTypes) {
-        assert(!knownInvalidTypes.has(usedType),
-            `${knownInvalidTypes.get(usedType)} ${usedType} cannot be used as a type`);
-        assert(knownTypes.has(usedType), `type ${usedType} is used but never defined`);
-      }
-
-      for (const attr of usedExtAttrs) {
-        assert(knownExtAttrs.has(attr), `extended attribute ${attr} is used but never defined`);
-      }
-    });
-
-    // Validate that Exposed attributes use only the identifiers from Global
-    // attributes.
-    it('contains consistent Exposed and Global extended attributes', function () {
-      // Get the identifiers (strings) from an extended attribute value as an
-      // array. Returns an array for both [Exposed=Window] and
-      // [Exposed=(Window,Worker)], '*' for the special [Exposed=*] wildcard and
-      // null for missing attribute.
-      function getExtAttrIdentifiers(node, name) {
-        const attr = getExtAttr(node, name);
-        if (!attr) {
-          return null;
-        }
-        switch (attr.rhs.type) {
-          case 'identifier':
-            return [attr.rhs.value];
-          case 'identifier-list':
-            return attr.rhs.value.map(({value}) => value);
-          case '*':
-            return '*';
-          default:
-            throw new Error(`Unexpected RHS for extended attribute ${name} on ${node.name}: ${attr.rhs?.type}`);
-        }
-      }
-
-      // Collect the known global identifiers.
-      const globals = new Set();
-      for (const dfn of dfns) {
-        const ids = getExtAttrIdentifiers(dfn, 'Global');
-        if (!ids) {
-          continue;
-        }
-        assert(Array.isArray(ids), `Unexpected Global attribute value on ${dfn.name}: ${ids}`);
-        for (const id of ids) {
-          globals.add(id);
-        }
-      }
-
-      // Check that some well known globals were found.
-      assert(globals.has('Window'), 'List of known globals does not include "Window"');
-      assert(globals.has('ServiceWorker'), 'List of known globals does not include "ServiceWorker"');
-
-      // Validate the Exposed extended attributes of top-level definitions and
-      // their members.
-      for (const dfn of dfns) {
-        const ids = getExtAttrIdentifiers(dfn, 'Exposed');
-        if (Array.isArray(ids)) {
-          for (const id of ids) {
-            assert(globals.has(id), `Exposed attribute value ${id} on ${dfn.name} does not match any known global name`);
-          }
-        }
-        if (dfn.members) {
-          for (const member of dfn.members) {
-            const ids = getExtAttrIdentifiers(member, 'Exposed');
-            if (Array.isArray(ids)) {
-              for (const id of ids) {
-                assert(globals.has(id), `Exposed attribute value ${id} on ${dfn.name}.${member.name} does not match any known global name`);
-              }
-            }
-          }
-        }
-      }
-    });
-
-    // This test should remain the last one as it slightly modifies objects in dfns in place.
-    it('yields consistent IDL when partials/mixins are merged', function () {
-      this.slow(1000);
-      const merged = merge(dfns, partials, includes);
-      // To guard against new things being added to Web IDL which need special handling,
-      // such as dictionary mixins, check that the merged result has only known types.
-      // Also check that everything has a name and that no partials remain.
-      const knownTypes = new Set([
-        'callback interface',
-        'callback',
-        'dictionary',
-        'enum',
-        'interface',
-        'namespace',
-        'typedef'
-      ]);
-      for (const dfn of merged) {
-        assert(dfn.name, 'definition has a name');
-        assert(!dfn.partial, 'definition is not partial');
-        assert(knownTypes.has(dfn.type), `unknown definition type: ${dfn.type}`)
-      }
+          return true;
+        });
+      assert.equal(report.length, 0, writeAnomalies(report));
     });
   });
 });


### PR DESCRIPTION
(@foolip FYI since you authored the initial Web IDL tests)

With this update, all Web IDL consistency tests are now run directly by Strudy. This allows to keep the test code simple and makes it possible to reuse the test logic in other contexts.

Nothing was lost in the switch. Guarantees still hold in particular. Strudy checks all IDL features that used to be checked in `consistency.js`, reporting anomalies in a more digestable form (which should make it slightly easier to find the root of a problem when one is found). Corresponding code in Strudy may be found in https://github.com/w3c/strudy/blob/main/src/lib/study-webidl.js

Strudy reports a couple of Web IDL issues that the previous code did not detect, namely the fact that the `Screen` interface needs to inherit from `EventTarget`, for use in the Window Management API, and the fact that the `*Track` interfaces need to be exposed on `DedicatedWorker`, for use in Media Source Extensions. These issues have been acknowledged by the groups that develop the specifications but the patch needs to be done against base interfaces that are under the control of other groups, and it's not clear to me that these other groups have acknowledged the issues yet. I did not feel like patching the IDL as a result. The tests currently explicitly ignore these issues for now in the interest of not blocking new package releases because of this.

Note: CI tests will currently fail because of the missing `EventTarget` inheritance on `SFrameTransform` (which was also not previously detected). I prepared https://github.com/w3c/webrtc-encoded-transform/pull/179. If that does not get merged soon-ish, I'll create a patch for this one on our side.