### PR TITLE
Add event patch for captured-mouse-events

### DIFF
--- a/tools/amend-event-data.js
+++ b/tools/amend-event-data.js
@@ -57,6 +57,14 @@ const patches = {
       change: { interface: "Event" }
     }
   ],
+  // Passive sentence used
+  'captured-mouse-events': [
+    {
+      pattern: { type: 'capturedmousechange' },
+      matched: 1,
+      change: { interface: "CapturedMouseEvent" }
+    }
+  ],
   // pending https://github.com/w3c/clipboard-apis/pull/181
   // see also https://github.com/w3c/clipboard-apis/issues/74
   'clipboard-apis': [


### PR DESCRIPTION
The specification uses a passive form for now.