### PR TITLE
Update captured-mouse-events patch

### DIFF
--- a/tools/amend-event-data.js
+++ b/tools/amend-event-data.js
@@ -57,12 +57,14 @@ const patches = {
       change: { interface: "Event" }
     }
   ],
-  // Passive sentence used
+  // Bubbles heuristic in Reffy is not smart enough to trap:
+  // "bubbles and cancelable attributes set to false"
+  // and incorrectly thinks occurence of "bubbles" means that the event bubbles.
   'captured-mouse-events': [
     {
       pattern: { type: 'capturedmousechange' },
       matched: 1,
-      change: { interface: "CapturedMouseEvent" }
+      change: { bubbles: false }
     }
   ],
   // pending https://github.com/w3c/clipboard-apis/pull/181


### PR DESCRIPTION
Former patch set the interface. The spec was fixed so interface no longer needs to be explicitly specified. That said, the "does not bubble" wording is correct but too complex for Reffy, who fails to parse "with its bubbles and cancelable attributes set to false" and then thinks that "bubbles" means that the event bubbles.

Note tests will likely fail until new crawl results are in with the interface.