### PR TITLE
Bump version of checkout and setup-node actions in jobs

### DIFF
--- a/.github/workflows/clean-patches.yml
+++ b/.github/workflows/clean-patches.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout webref
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: 18
 
@@ -28,7 +28,7 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Create PR to drop patches from repo if needed
-      uses: peter-evans/create-pull-request@v3
+      uses: peter-evans/create-pull-request@v5
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout webref
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: 18
     - name: Run clean up
       run: node tools/clean-abandoned-files.js
-    - uses: peter-evans/create-pull-request@v3
+    - uses: peter-evans/create-pull-request@v5
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/curate.yml
+++ b/.github/workflows/curate.yml
@@ -23,12 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: 18
 
     - name: Checkout webref
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         # Need to checkout all history as curation job also needs to access
         # the curated branch

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: 18
 
     - name: Checkout latest version of release script
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: main
 

--- a/.github/workflows/request-pr-review.yml
+++ b/.github/workflows/request-pr-review.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: 18
 
     - name: Checkout webref
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,8 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
       with:
         node-version: 18
     - name: Install dependencies

--- a/.github/workflows/update-ed.yml
+++ b/.github/workflows/update-ed.yml
@@ -8,22 +8,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: 18
 
-    # Temp (2023-01-07): Force version of node-fetch, pending resolution of:
-    # https://github.com/node-fetch/node-fetch/issues/1701
     - name: Install reffy
-      run: |
-        npm install node-fetch@2.6.7
-        npm install reffy
+      run: npm install reffy
 
     # Use a separate checkout to reduce the chances
     # that, by the time the crawl has ended, the underlying webref checkout
     # that gets updated be no longer in sync with origin
     - name: Checkout webref-fallback
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: webref-fallback
 
@@ -35,7 +31,7 @@ jobs:
         node_modules/.bin/reffy --post csscomplete --post annotatelinks --post patchdfns --output report --fallback webref-fallback/ed/index.json --spec all DOM-Level-2-Style selectors-nonelement-1 tracking-dnt
 
     - name: Checkout webref
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: webref
 

--- a/.github/workflows/update-tr.yml
+++ b/.github/workflows/update-tr.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: 18
 
@@ -19,7 +19,7 @@ jobs:
     # that, by the time the crawl has ended, the underlying webref checkout
     # that gets updated be no longer in sync with origin
     - name: Checkout webref-fallback
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: webref-fallback
 
@@ -29,7 +29,7 @@ jobs:
         node_modules/.bin/reffy --release --post csscomplete --post annotatelinks --post patchdfns --output report --fallback webref-fallback/tr/index.json
 
     - name: Checkout webref
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: webref
 


### PR DESCRIPTION
Switch the latest major versions to avoid running an older version of Node.js.

(No caching for now, job logic will need to change slightly because main ones don't run `npm ci` but rather install packages explicitly).