### PR TITLE
Enable dependency caching in jobs

### DIFF
--- a/.github/workflows/clean-patches.yml
+++ b/.github/workflows/clean-patches.yml
@@ -15,12 +15,10 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 18
+        cache: 'npm'
 
     - name: Install dependencies
-      run: |
-        npm install --no-save @actions/core
-        npm install --no-save @octokit/rest
-        npm install --no-save @octokit/plugin-throttling
+      run: npm ci
 
     - name: Drop patches locally when related issues/PR are closed
       run: node tools/clean-patches.js

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -14,6 +14,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 18
+        cache: 'npm'
     - name: Run clean up
       run: node tools/clean-abandoned-files.js
     - uses: peter-evans/create-pull-request@v5

--- a/.github/workflows/curate.yml
+++ b/.github/workflows/curate.yml
@@ -22,17 +22,18 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     steps:
-    - name: Setup node.js
-      uses: actions/setup-node@v3
-      with:
-        node-version: 18
-
     - name: Checkout webref
       uses: actions/checkout@v3
       with:
         # Need to checkout all history as curation job also needs to access
         # the curated branch
         fetch-depth: 0
+
+    - name: Setup node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18
+        cache: 'npm'
 
     - name: Install dependencies
       run: npm ci

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -16,22 +16,19 @@ jobs:
     if: startsWith(github.head_ref, 'release-') && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-    - name: Setup node.js
-      uses: actions/setup-node@v3
-      with:
-        node-version: 18
-
     - name: Checkout latest version of release script
       uses: actions/checkout@v3
       with:
         ref: main
 
+    - name: Setup node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18
+        cache: 'npm'
+
     - name: Install dependencies
-      run: |
-        npm install --no-save @octokit/rest
-        npm install --no-save @octokit/plugin-throttling
-        npm install --no-save rimraf
-        npm install --no-save @jsdevtools/npm-publish
+      run: npm ci
 
     - name: Release package if needed
       run: node tools/release-package.js ${{ github.event.pull_request.number }}

--- a/.github/workflows/request-pr-review.yml
+++ b/.github/workflows/request-pr-review.yml
@@ -9,18 +9,17 @@ jobs:
   review:
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout webref
+      uses: actions/checkout@v3
+
     - name: Setup node.js
       uses: actions/setup-node@v3
       with:
         node-version: 18
-
-    - name: Checkout webref
-      uses: actions/checkout@v3
+        cache: 'npm'
 
     - name: Install dependencies
-      run: |
-        npm install --no-save @octokit/rest
-        npm install --no-save @octokit/plugin-throttling
+      run: npm ci
 
     - name: Request review of pre-release PR
       run: node tools/request-pr-review.js

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ jobs:
     - uses: actions/setup-node@v3
       with:
         node-version: 18
+        cache: 'npm'
     - name: Install dependencies
       run: npm ci
     - name: Prepare curated and packages data

--- a/.github/workflows/update-ed.yml
+++ b/.github/workflows/update-ed.yml
@@ -7,30 +7,28 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+
     - name: Setup node.js
       uses: actions/setup-node@v3
       with:
         node-version: 18
+        cache: 'npm'
 
-    - name: Install reffy
-      run: npm install reffy
-
-    # Use a separate checkout to reduce the chances
-    # that, by the time the crawl has ended, the underlying webref checkout
-    # that gets updated be no longer in sync with origin
-    - name: Checkout webref-fallback
-      uses: actions/checkout@v3
-      with:
-        path: webref-fallback
+    - name: Install dependencies
+      run: npm ci
 
     # Note command to Reffy explicitly mentions a few discontinued specs,
     # kept in the crawl for cross-referencing purpose.
     - name: Run Reffy's crawler
       run: |
         mkdir report
-        node_modules/.bin/reffy --post csscomplete --post annotatelinks --post patchdfns --output report --fallback webref-fallback/ed/index.json --spec all DOM-Level-2-Style selectors-nonelement-1 tracking-dnt
+        node_modules/.bin/reffy --post csscomplete --post annotatelinks --post patchdfns --output report --fallback ed/index.json --spec all DOM-Level-2-Style selectors-nonelement-1 tracking-dnt
 
-    - name: Checkout webref
+    # Update another Webref checkout to reduce the chances that the version we
+    # checked out is no longer in sync with origin by the time the crawl is over
+    - name: Checkout webref once more
       uses: actions/checkout@v3
       with:
         path: webref

--- a/.github/workflows/update-tr.yml
+++ b/.github/workflows/update-tr.yml
@@ -7,27 +7,25 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+
     - name: Setup node.js
       uses: actions/setup-node@v3
       with:
         node-version: 18
+        cache: 'npm'
 
-    - name: Install reffy
-      run: npm install reffy
-
-    # Use a separate checkout to reduce the chances
-    # that, by the time the crawl has ended, the underlying webref checkout
-    # that gets updated be no longer in sync with origin
-    - name: Checkout webref-fallback
-      uses: actions/checkout@v3
-      with:
-        path: webref-fallback
+    - name: Install dependencies
+      run: npm ci
 
     - name: Run Reffy's crawler
       run: |
         mkdir report
-        node_modules/.bin/reffy --release --post csscomplete --post annotatelinks --post patchdfns --output report --fallback webref-fallback/tr/index.json
+        node_modules/.bin/reffy --release --post csscomplete --post annotatelinks --post patchdfns --output report --fallback tr/index.json
 
+    # Update another Webref checkout to reduce the chances that the version we
+    # checked out is no longer in sync with origin by the time the crawl is over
     - name: Checkout webref
       uses: actions/checkout@v3
       with:


### PR DESCRIPTION
Hopefully, that will fix the transient Puppeteer installation errors that we seem to get nowadays when jobs run.

Note this rewrites slightly the logic of the update jobs, but that should make things slightly more straightforward (job could be further simplified to replace the double checkout with a simple checkout, followed by a `git pull` after the crawl).

The use of `npm ci` throughout the jobs means that we're now de facto pinning down the version of Reffy that the crawler uses, as envisioned in #849. This requires a manual action to bump the version in Webref when we release a new version of Reffy but that's a cleaner approach.