### PR TITLE
Make css-borders-4 supersede css-backgrounds-3

### DIFF
--- a/tools/drop-css-property-duplicates.js
+++ b/tools/drop-css-property-duplicates.js
@@ -57,6 +57,11 @@ const supersededBy = {
   // https://drafts.csswg.org/css-conditional-5/#at-supports-ext
   'css-conditional': 'css-fonts',
 
+  // css-backgrounds-3 was split into css-backgrounds-4 and css-borders-4.
+  // This override can be dropped once css-backgrounds-4 becomes the current
+  // specification in the css-backgrounds series.
+  'css-backgrounds': 'css-borders',
+
   // The Selectors spec defines the ":fullscreen" selector, which is refined in
   // Fullscreen. The Fullscreen definition should probably be flagged as non
   // exported. Or turned into a reference to the Selectors spec.


### PR DESCRIPTION
For the context, see https://github.com/w3c/browser-specs/issues/1025

css-borders-4 extends some of the property declarations of css-backgrounds-3 (`border-xxx-radius`, `border-xxx-color`). This creates duplicate CSS property definitions in Webref.

If we were to consider css-borders-4 as a delta spec, we would just do nothing and leave de-duplication up to consumers. Here, we need to select one. If we favor css-backgrounds-3 definitions, e.g., on the ground that they are more stable, we would have to reverse that choice later on when that stops being the case. Favoring css-borders-4 definitions seems more future-proof. Plus the new definitions are backward-compatible with former ones.