### PR TITLE
Add patch for ed/css/css-gcpm.json

### DIFF
--- a/ed/csspatches/css-gcpm.json.patch
+++ b/ed/csspatches/css-gcpm.json.patch
@@ -1,0 +1,29 @@
+From 963815da4286f6853601d9df548f2f99f4e53f87 Mon Sep 17 00:00:00 2001
+From: Francois Daoust <fd@tidoust.net>
+Date: Fri, 15 Sep 2023 12:08:20 +0200
+Subject: [PATCH] Rollback definition of :nth() to please parser
+
+Rolling back pending support in CSSTree for `<an+b>` or some other resolution:
+https://github.com/csstree/csstree/issues/263
+
+Rollback is partial, keeping the `:nth` prefixing.
+---
+ ed/css/css-gcpm.json | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ed/css/css-gcpm.json b/ed/css/css-gcpm.json
+index f49de232a..17999a9ec 100644
+--- a/ed/css/css-gcpm.json
++++ b/ed/css/css-gcpm.json
+@@ -123,7 +123,7 @@
+   "selectors": [
+     {
+       "name": ":nth()",
+-      "value": ":nth( <an+b> [of <custom-ident>]? )"
++      "value": ":nth( An+B [of <custom-ident>]?)"
+     }
+   ],
+   "values": [
+-- 
+2.37.1.windows.1
+


### PR DESCRIPTION
Rolling back definition of `:nth()` pending support in CSSTree for `<an+b>` or some other resolution.

(CI tests will continue to fail because of an edit-context event issue. That's unrelated)