### PR TITLE
Update patch for ed/idl/web-animations-2.idl to rollback range changes

### DIFF
--- a/ed/idlpatches/web-animations-2.idl.patch
+++ b/ed/idlpatches/web-animations-2.idl.patch
@@ -1,22 +1,35 @@
-From ea2e5beb27b21ea54c3633c0282e71f1d9e14393 Mon Sep 17 00:00:00 2001
-From: Kagami Sascha Rosylight <saschanaz@outlook.com>
-Date: Thu, 1 Jul 2021 13:35:40 +0200
-Subject: [PATCH] Drop duplicate `fillMode` enum definition
+From 06ad7a19726182d0f81ff10fd43ad0cc31ca1a0d Mon Sep 17 00:00:00 2001
+From: Francois Daoust <fd@tidoust.net>
+Date: Fri, 29 Sep 2023 08:51:32 +0200
+Subject: [PATCH] Drop duplicate `fillMode` enum definition, rollback range
+ changes
 
-The spec is a delta spec and re-defines the enum to change the meaning of one of
-its values.
+The spec is a delta spec and re-defines the `fillMode` enum to change the
+meaning of one of its values.
 
 Patch will likely need to be kept around for as long as the spec remains a delta
 spec.
+
+The `rangeStart` and `rangeEnd` definitions are currently invalid, pending:
+https://github.com/w3c/csswg-drafts/pull/9360
 ---
- ed/idl/web-animations-2.idl | 2 --
- 1 file changed, 2 deletions(-)
+ ed/idl/web-animations-2.idl | 4 ----
+ 1 file changed, 4 deletions(-)
 
 diff --git a/ed/idl/web-animations-2.idl b/ed/idl/web-animations-2.idl
-index 1b5db8b13..2bc7aa412 100644
+index cba20b25f..f9f68a0d4 100644
 --- a/ed/idl/web-animations-2.idl
 +++ b/ed/idl/web-animations-2.idl
-@@ -38,8 +38,6 @@ partial dictionary ComputedEffectTiming {
+@@ -14,8 +14,6 @@ partial interface AnimationTimeline {
+ partial interface Animation {
+     attribute CSSNumberish?       startTime;
+     attribute CSSNumberish?       currentTime;
+-    attribute (TimelineRangeOffset or CSSNumericValue or CSSKeywordValue or DOMString) rangeStart;
+-    attribute (TimelineRangeOffset or CSSNumericValue or CSSKeywordValue or DOMString) rangeEnd;
+ };
+ 
+ [Exposed=Window]
+@@ -49,8 +47,6 @@ partial dictionary ComputedEffectTiming {
      CSSNumberish?        localTime;
  };
  
@@ -26,5 +39,5 @@ index 1b5db8b13..2bc7aa412 100644
  interface GroupEffect {
    constructor(sequence<AnimationEffect>? children,
 -- 
-2.32.0.windows.1
+2.37.1.windows.1
 


### PR DESCRIPTION
Note CI tests will still fail, but things should (hopefully) turn green once a new crawl runs.