### PR TITLE
Add patch for ed/idl/css-view-transitions-2.idl

### DIFF
--- a/ed/idlpatches/css-view-transitions-2.idl.patch
+++ b/ed/idlpatches/css-view-transitions-2.idl.patch
@@ -1,0 +1,29 @@
+From 4df066accf11c29efad58c7bc4c5fde6d94d909a Mon Sep 17 00:00:00 2001
+From: Francois Daoust <fd@tidoust.net>
+Date: Tue, 7 Nov 2023 11:28:57 +0100
+Subject: [PATCH] Add default value for startViewTransition argument
+
+Pending https://github.com/w3c/csswg-drafts/pull/9497
+
+(The "must have a default value" rule may be a bit too strict for such a union,
+but the default value does not introduce a substantive change in any case)
+---
+ ed/idl/css-view-transitions-2.idl | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ed/idl/css-view-transitions-2.idl b/ed/idl/css-view-transitions-2.idl
+index 3c34d67ce..f133ae3e9 100644
+--- a/ed/idl/css-view-transitions-2.idl
++++ b/ed/idl/css-view-transitions-2.idl
+@@ -15,7 +15,7 @@ dictionary StartViewTransitionOptions {
+ 
+ partial interface Document {
+ 
+-  ViewTransition startViewTransition(optional (UpdateCallback or StartViewTransitionOptions) callbackOptions);
++  ViewTransition startViewTransition(optional (UpdateCallback or StartViewTransitionOptions) callbackOptions = {});
+ };
+ 
+ partial interface CSSRule {
+-- 
+2.37.1.windows.1
+


### PR DESCRIPTION
The "must have a default value" rule may be a bit too strict for such a union, but I think we established that the default value does not introduce a substantive change in any case.