### PR TITLE
Switch jobs to use Node.js v20

### DIFF
--- a/.github/workflows/clean-patches.yml
+++ b/.github/workflows/clean-patches.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 20
         cache: 'npm'
 
     - name: Install dependencies

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 20
         cache: 'npm'
     - name: Run clean up
       run: node tools/clean-abandoned-files.js

--- a/.github/workflows/curate.yml
+++ b/.github/workflows/curate.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 20
         cache: 'npm'
 
     - name: Install dependencies

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 20
         cache: 'npm'
 
     - name: Install dependencies

--- a/.github/workflows/request-pr-review.yml
+++ b/.github/workflows/request-pr-review.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 20
         cache: 'npm'
 
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 20
         cache: 'npm'
     - name: Install dependencies
       run: npm ci

--- a/.github/workflows/update-ed.yml
+++ b/.github/workflows/update-ed.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 20
         cache: 'npm'
 
     - name: Install dependencies

--- a/.github/workflows/update-tr.yml
+++ b/.github/workflows/update-tr.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 20
         cache: 'npm'
 
     - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "devDependencies": {
     "@actions/core": "1.10.1",


### PR DESCRIPTION
Some dependency updates seem to require Node.js v20. Switching all jobs for consistency.