### PR TITLE
Temporarily force crawl of discontinued RFCs

### DIFF
--- a/.github/workflows/update-ed.yml
+++ b/.github/workflows/update-ed.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Run Reffy's crawler
       run: |
         mkdir report
-        node_modules/.bin/reffy --post csscomplete --post annotatelinks --post patchdfns --output report --fallback ed/index.json --spec all DOM-Level-2-Style selectors-nonelement-1 tracking-dnt
+        node_modules/.bin/reffy --post csscomplete --post annotatelinks --post patchdfns --output report --fallback ed/index.json --spec all DOM-Level-2-Style selectors-nonelement-1 tracking-dnt rfc7230 rfc7231 rfc7232 rfc7233 rfc7234 rfc7235 rfc7538 rfc7540
 
     # Update another Webref checkout to reduce the chances that the version we
     # checked out is no longer in sync with origin by the time the crawl is over


### PR DESCRIPTION
The status of some RFCs that used to be crawled by Reffy has recently (and correctly) been switched to discontinued, see list in: https://github.com/w3c/browser-specs/issues/327#issuecomment-1823278033

There are a bunch (*) of specs that still reference these discontinued specs. This update makes Reffy continue to crawl the RFCs to give us more time to update all specs, or at least to alert them that they need some update.

(*) I will prepare an explicit list of such specs.