### PR TITLE
Make css-borders-4 supersede css-logical-1

### DIFF
--- a/tools/drop-css-property-duplicates.js
+++ b/tools/drop-css-property-duplicates.js
@@ -33,7 +33,11 @@ const supersededBy = {
   'css-flexbox': 'css-align',
 
   // https://github.com/w3c/csswg-drafts/issues/6434#issuecomment-877447360
-  'css-logical': 'css-position',
+  // https://drafts.csswg.org/css-borders-4/#level-changes
+  'css-logical': [
+    'css-position',
+    'css-borders'
+  ],
 
   // See https://github.com/w3c/csswg-drafts/issues/6435
   // (string-set property defined twice)


### PR DESCRIPTION
See https://drafts.csswg.org/css-borders-4/#level-changes

Note that's going to fix curation but CI tests will continue to fail due to invalid Web IDL in the MSE draft.