### PR TITLE
Add patch for ed/idl/custom-state-pseudo-class.idl

### DIFF
--- a/ed/idlpatches/custom-state-pseudo-class.idl.patch
+++ b/ed/idlpatches/custom-state-pseudo-class.idl.patch
@@ -1,0 +1,35 @@
+From 0223b3aa0ed98ddb6d0185458916fd6bc87c9869 Mon Sep 17 00:00:00 2001
+From: Francois Daoust <fd@tidoust.net>
+Date: Tue, 26 Dec 2023 04:05:15 +0100
+Subject: [PATCH] Drop IDL extract of custom-state-pseudo-class
+
+Spec not updated yet, but the IDL was merged into HTML. Pending deprecation in
+browser-specs in https://github.com/w3c/browser-specs/pull/1164
+---
+ ed/idl/custom-state-pseudo-class.idl | 14 --------------
+ 1 file changed, 14 deletions(-)
+ delete mode 100644 ed/idl/custom-state-pseudo-class.idl
+
+diff --git a/ed/idl/custom-state-pseudo-class.idl b/ed/idl/custom-state-pseudo-class.idl
+deleted file mode 100644
+index 342f1ede0..000000000
+--- a/ed/idl/custom-state-pseudo-class.idl
++++ /dev/null
+@@ -1,14 +0,0 @@
+-// GENERATED CONTENT - DO NOT EDIT
+-// Content was automatically extracted by Reffy into webref
+-// (https://github.com/w3c/webref)
+-// Source: Custom State Pseudo Class (https://wicg.github.io/custom-state-pseudo-class/)
+-
+-partial interface ElementInternals {
+-  readonly attribute CustomStateSet states;
+-};
+-
+-[Exposed=Window]
+-interface CustomStateSet {
+-  setlike<DOMString>;
+-  undefined add(DOMString value);
+-};
+-- 
+2.37.1.windows.1
+


### PR DESCRIPTION
Drop IDL extract of custom-state-pseudo-class. Pending deprecation in
browser-specs in https://github.com/w3c/browser-specs/pull/1164