### PR TITLE
Fix curation of index.json when events are patched

### DIFF
--- a/tools/amend-event-data.js
+++ b/tools/amend-event-data.js
@@ -540,7 +540,8 @@ function applyEventPatches(spec) {
 
 async function curateEvents(folder) {
   const rawIndex = await loadJSON(path.join(folder, 'index.json'));
-  const index = await expandCrawlResult(rawIndex, folder, ['events']);
+  const index = JSON.parse(JSON.stringify(rawIndex));
+  await expandCrawlResult(index, folder, ['events']);
 
   async function saveEvents(spec) {
     const pathname = path.join(folder, 'events', spec.shortname + '.json');
@@ -587,7 +588,7 @@ async function curateEvents(folder) {
       delete s.events;
     }
     else if (!s.events && index.results.find(ss => ss.url === s.url).events?.length > 0) {
-      s.events = `events/${spec.shortname}.json`;
+      s.events = `events/${s.shortname}.json`;
     }
   });
   const json = JSON.stringify(rawIndex, null, 2) + '\n';


### PR DESCRIPTION
The code that patches events updates the curated `index.json` file to add or remove links to events files. But the code missed the fact that `expandCrawlResults` expands the list in place. The updated `index.json` contained a list with expanded events as a result.

Now, this gets fixed down the road because curation re-generates the curated index later on. But it only does so *after* having removed extracts of pending specs, and the code that removed extracts of pending specs expects to find links to extract files, not expanded results. Event extracts of pending specs were not removed as a result.

This bug explains why curation failed in:
https://github.com/w3c/webref/actions/runs/7537909004/job/20517559258

The code now makes a copy of the curated `index.json` file before calling `expandCrawlResults`, so that the code that updates the file afterwards actually runs on the initial contents of the file and not on the expanded version.