### PR TITLE
[test] Add SnapEvent to dangling event exception list

### DIFF
--- a/test/events/all.js
+++ b/test/events/all.js
@@ -131,6 +131,7 @@ before(async () => {
       assert.deepEqual(
         eventInterfaces.filter(iface => !usedEventInterfaces.has(iface)),
         [
+          'SnapEvent', // pending https://github.com/w3c/csswg-drafts/issues/7442
           'CustomEvent', // not used by any spec
           'PaymentRequestUpdateEvent' // pending https://github.com/w3c/payment-request/issues/991
         ],


### PR DESCRIPTION
Definition of the `SnapEvent` interface was added to css-scroll-snap-2, but the definition of the events themselves has not been fixed yet, and the interface is thus not referenced from anywhere for now.