### PR TITLE
Patch interface used by the install event in Service Workers

### DIFF
--- a/tools/amend-event-data.js
+++ b/tools/amend-event-data.js
@@ -321,6 +321,12 @@ const patches = {
       pattern: { href: "https://wicg.github.io/BackgroundSync/spec/#sync" },
       matched: 1,
       change: { href: "https://wicg.github.io/background-sync/spec/#sync"}
+    },
+    // pending https://github.com/w3c/ServiceWorker/pull/1706
+    {
+      pattern: { type: "install" },
+      matched: 1,
+      change: { interface: "InstallEvent" }
     }
   ],
   'speech-api': [


### PR DESCRIPTION
Pending https://github.com/w3c/ServiceWorker/pull/1706. Our consistency tests fail otherwise because it cannot link the new `InstallEvent` interface to any event.

(Side note: the `amend-event-data.js` contains patches that should no longer be needed. At least, the underlying pending PRs got merged. I'll clean things up separately.)