### PR TITLE
Adjust case of CSS Scroll Snap events to delete

### DIFF
--- a/tools/amend-event-data.js
+++ b/tools/amend-event-data.js
@@ -146,7 +146,7 @@ const patches = {
   'css-scroll-snap-2': [
     // deleting until we have clarity on the events https://github.com/w3c/csswg-drafts/issues/7442
     {
-      pattern: { type: /^snapChang(ed|ing)$/ },
+      pattern: { type: /^snapchang(ed|ing)$/ },
       matched: 2,
       delete: true
     }


### PR DESCRIPTION
The spec now uses lower case event types. Patch is still needed as the naming question is still under discussion.

Note: CI tests will continue to fail because of invalid Web IDL in other specs.