### PR TITLE
Re-generate patch for ed/idl/css-view-transitions-2.idl

### DIFF
--- a/ed/idlpatches/css-view-transitions-2.idl.patch
+++ b/ed/idlpatches/css-view-transitions-2.idl.patch
@@ -1,6 +1,6 @@
-From ab0c6ef3229612914cbdce9db6aa2de94d583e2c Mon Sep 17 00:00:00 2001
+From ebb2592055a4d210eb41098ec0ac9e2f14d03212 Mon Sep 17 00:00:00 2001
 From: Francois Daoust <fd@tidoust.net>
-Date: Wed, 27 Mar 2024 08:24:00 +0100
+Date: Tue, 2 Apr 2024 14:55:32 +0200
 Subject: [PATCH] Add `[Exposed]` to `ViewTransitionTypeSet`
 
 Pending https://github.com/w3c/csswg-drafts/pull/10123
@@ -9,11 +9,11 @@ Pending https://github.com/w3c/csswg-drafts/pull/10123
  1 file changed, 1 insertion(+)
 
 diff --git a/ed/idl/css-view-transitions-2.idl b/ed/idl/css-view-transitions-2.idl
-index ced3477dc..41337f4e1 100644
+index 7ce984a9d..21c25d3b9 100644
 --- a/ed/idl/css-view-transitions-2.idl
 +++ b/ed/idl/css-view-transitions-2.idl
-@@ -20,6 +20,7 @@ interface CSSViewTransitionRule : CSSRule {
-   readonly attribute CSSViewTransitionTypeSet types;
+@@ -15,6 +15,7 @@ interface CSSViewTransitionRule : CSSRule {
+   readonly attribute FrozenArray<CSSOMString> types;
  };
  
 +[Exposed=Window]


### PR DESCRIPTION
Add `[Exposed]` to `ViewTransitionTypeSet`

Note: CI tests will continue to fail due to another IDL hiccup