### PR TITLE
Set `cancelable` flag for "cancel" event (dialog and CloseWatcher)

### DIFF
--- a/tools/amend-event-data.js
+++ b/tools/amend-event-data.js
@@ -189,18 +189,24 @@ const patches = {
     // (This is not a temporary fix: "HTMLElement" is the correct target
     // interface from a spec perspective, that's where the event handlers are
     // defined)
-    // Also, the "cancel" event bubbles on input elements but not on other
-    // target interfaces, so we need to duplicate the entry in the extract.
+    // Also, the "cancel" event bubbles but is not cancelable on input elements
+    // while it is (potentially) cancelable but does not bubble on other target
+    // interfaces, so we need to duplicate the entry in the extract.
     {
       pattern: { type: "cancel"},
       matched: 1,
-      change: { targets: ["HTMLInputElement"] }
+      change: {
+        bubbles: true,
+        cancelable: false,
+        targets: ["HTMLInputElement"]
+      }
     },
     {
       add: {
         type: "cancel",
         interface: "Event",
         bubbles: false,
+        cancelable: true,
         targets: ["CloseWatcher", "HTMLDialogElement"],
         href: "https://html.spec.whatwg.org/multipage/indices.html#event-cancel",
         src: {


### PR DESCRIPTION
A recent HTML update changed the creation conditions for the "cancel" event for `HTMLDialogElement` and `CloseWatcher`:
https://github.com/whatwg/html/pull/10291/files

The extraction code no longer detects the `cancelable` flag as a result.

In any case, the code that amended the event to split `HTMLElement` into `HTMLInputElement` and `HTMLDialogElement` was incorrect: the `cancelable` flag ended up on `HTMLInputElement` whereas it should have been set on the other two target interfaces. The amendment is now explicit on both `bubbles` and `cancelable` to avoid any bad surprise.

One interesting aspect of the HTML update is that it seems to make the event cancelable depending on conditions. We cannot express that nuance with a boolean flag... I propose to set the flag to `true`.