### PR TITLE
Replace XMLHttpRequestEventTarget with its subclasses as event target

### DIFF
--- a/tools/amend-event-data.js
+++ b/tools/amend-event-data.js
@@ -412,6 +412,13 @@ const patches = {
       change: { interface: "Event" }
     }
   ],
+  'xhr': [
+    {
+      pattern: { targets: 'XMLHttpRequestEventTarget' },
+      matched: 7,
+      change: { targets: ['XMLHttpRequest', 'XMLHttpRequestUpload'] }
+    }
+  ],
   'webaudio': [
     {
       pattern: { type: 'update' },


### PR DESCRIPTION
see https://github.com/w3c/webref/issues/1216#issuecomment-2068997553