### PR TITLE
Fix CSS test on base property definitions

### DIFF
--- a/test/css/all.js
+++ b/test/css/all.js
@@ -29,6 +29,7 @@ describe(`The curated view of CSS extracts`, () => {
   before(async () => {
     const all = await css.listAll({ folder: curatedFolder });
     const baseProperties = {};
+    const basePropertiesInDeltaSpecs = {};
     const extendedProperties = {};
     const selectors = {};
     const valuespaces = {};
@@ -50,6 +51,12 @@ describe(`The curated view of CSS extracts`, () => {
                 baseProperties[name] = [];
               }
               baseProperties[name].push({ spec: data.spec, dfn: desc });
+            }
+            else if ((type === 'property') && (spec.seriesComposition === 'delta') && !desc.newValues) {
+              if (!basePropertiesInDeltaSpecs[name]) {
+                basePropertiesInDeltaSpecs[name] = [];
+              }
+              basePropertiesInDeltaSpecs[name].push({ spec: data.spec, dfn: desc });
             }
             else if ((type === 'extended property') && desc[value]) {
               if (!extendedProperties[name]) {
@@ -154,7 +161,7 @@ describe(`The curated view of CSS extracts`, () => {
     describe(`Looking at extended CSS properties, the curated view`, () => {
       for (const [name, dfns] of Object.entries(extendedProperties)) {
         it(`contains a base definition for the "${name}" property`, () => {
-          assert(baseProperties[name], 'no base definition found');
+          assert(baseProperties[name] || basePropertiesInDeltaSpecs[name], 'no base definition found');
         });
       }
     });


### PR DESCRIPTION
The test did not take into account the possibility that the base definition of a CSS property could be in a delta spec. That's currently the case for the `continue` property: defined in `css-overflow-4`, extended in `css-overflow-5`.

Not done here but the test could also be extended to make sure that the base definition is defined in a delta spec that is logically *before* the spec that extends the definition. The use of a separate array is meant to ease that further update.

Closes #1272.