### PR TITLE
Rollback version of `@octokit/rest`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@actions/core": "1.10.1",
         "@jsdevtools/npm-publish": "3.1.1",
         "@octokit/plugin-throttling": "^8.1.3",
-        "@octokit/rest": "21.0.0",
+        "@octokit/rest": "20.1.1",
         "@webref/css": "file:packages/css",
         "@webref/elements": "file:packages/elements",
         "@webref/events": "file:packages/events",
@@ -480,139 +480,19 @@
       }
     },
     "node_modules/@octokit/rest": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-21.0.0.tgz",
-      "integrity": "sha512-XudXXOmiIjivdjNZ+fN71NLrnDM00sxSZlhqmPR3v0dVoJwyP628tSlc12xqn8nX3N0965583RBw5GPo6r8u4Q==",
+      "version": "20.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.1.1.tgz",
+      "integrity": "sha512-MB4AYDsM5jhIHro/dq4ix1iWTLGToIGk6cWF5L6vanFaMble5jTX/UBQyiv05HsWnwUtY8JrfHy2LWfKwihqMw==",
       "dev": true,
       "dependencies": {
-        "@octokit/core": "^6.1.2",
-        "@octokit/plugin-paginate-rest": "^11.0.0",
-        "@octokit/plugin-request-log": "^5.1.0",
-        "@octokit/plugin-rest-endpoint-methods": "^13.0.0"
+        "@octokit/core": "^5.0.2",
+        "@octokit/plugin-paginate-rest": "11.3.1",
+        "@octokit/plugin-request-log": "^4.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "13.2.2"
       },
       "engines": {
         "node": ">= 18"
       }
-    },
-    "node_modules/@octokit/rest/node_modules/@octokit/auth-token": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.1.tgz",
-      "integrity": "sha512-rh3G3wDO8J9wSjfI436JUKzHIxq8NaiL0tVeB2aXmG6p/9859aUOAjA9pmSPNGGZxfwmaJ9ozOJImuNVJdpvbA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/rest/node_modules/@octokit/core": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.2.tgz",
-      "integrity": "sha512-hEb7Ma4cGJGEUNOAVmyfdB/3WirWMg5hDuNFVejGEDFqupeOysLc2sG6HJxY2etBp5YQu5Wtxwi020jS9xlUwg==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/auth-token": "^5.0.0",
-        "@octokit/graphql": "^8.0.0",
-        "@octokit/request": "^9.0.0",
-        "@octokit/request-error": "^6.0.1",
-        "@octokit/types": "^13.0.0",
-        "before-after-hook": "^3.0.2",
-        "universal-user-agent": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/rest/node_modules/@octokit/endpoint": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.1.tgz",
-      "integrity": "sha512-JYjh5rMOwXMJyUpj028cu0Gbp7qe/ihxfJMLc8VZBMMqSwLgOxDI1911gV4Enl1QSavAQNJcwmwBF9M0VvLh6Q==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/types": "^13.0.0",
-        "universal-user-agent": "^7.0.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/rest/node_modules/@octokit/graphql": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.1.1.tgz",
-      "integrity": "sha512-ukiRmuHTi6ebQx/HFRCXKbDlOh/7xEV6QUXaE7MJEKGNAncGI/STSbOkl12qVXZrfZdpXctx5O9X1AIaebiDBg==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/request": "^9.0.0",
-        "@octokit/types": "^13.0.0",
-        "universal-user-agent": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/rest/node_modules/@octokit/openapi-types": {
-      "version": "22.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
-      "integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
-      "dev": true
-    },
-    "node_modules/@octokit/rest/node_modules/@octokit/plugin-request-log": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-5.3.0.tgz",
-      "integrity": "sha512-FiGcyjdtYPlr03ExBk/0ysIlEFIFGJQAVoPPMxL19B24bVSEiZQnVGBunNtaAF1YnvE/EFoDpXmITtRnyCiypQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=6"
-      }
-    },
-    "node_modules/@octokit/rest/node_modules/@octokit/request": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.1.tgz",
-      "integrity": "sha512-pyAguc0p+f+GbQho0uNetNQMmLG1e80WjkIaqqgUkihqUp0boRU6nKItXO4VWnr+nbZiLGEyy4TeKRwqaLvYgw==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/endpoint": "^10.0.0",
-        "@octokit/request-error": "^6.0.1",
-        "@octokit/types": "^13.1.0",
-        "universal-user-agent": "^7.0.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/rest/node_modules/@octokit/request-error": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.1.tgz",
-      "integrity": "sha512-1mw1gqT3fR/WFvnoVpY/zUM2o/XkMs/2AszUUG9I69xn0JFLv6PGkPhNk5lbfvROs79wiS0bqiJNxfCZcRJJdg==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/types": "^13.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/rest/node_modules/@octokit/types": {
-      "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.5.0.tgz",
-      "integrity": "sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/openapi-types": "^22.2.0"
-      }
-    },
-    "node_modules/@octokit/rest/node_modules/before-after-hook": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
-      "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
-      "dev": true
-    },
-    "node_modules/@octokit/rest/node_modules/universal-user-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
-      "integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==",
-      "dev": true
     },
     "node_modules/@octokit/types": {
       "version": "11.1.0",
@@ -3110,21 +2990,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/strudy/node_modules/@octokit/rest": {
-      "version": "20.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.1.1.tgz",
-      "integrity": "sha512-MB4AYDsM5jhIHro/dq4ix1iWTLGToIGk6cWF5L6vanFaMble5jTX/UBQyiv05HsWnwUtY8JrfHy2LWfKwihqMw==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/core": "^5.0.2",
-        "@octokit/plugin-paginate-rest": "11.3.1",
-        "@octokit/plugin-request-log": "^4.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "13.2.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/strudy/node_modules/ajv": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.15.0.tgz",
@@ -3989,114 +3854,15 @@
       }
     },
     "@octokit/rest": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-21.0.0.tgz",
-      "integrity": "sha512-XudXXOmiIjivdjNZ+fN71NLrnDM00sxSZlhqmPR3v0dVoJwyP628tSlc12xqn8nX3N0965583RBw5GPo6r8u4Q==",
+      "version": "20.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.1.1.tgz",
+      "integrity": "sha512-MB4AYDsM5jhIHro/dq4ix1iWTLGToIGk6cWF5L6vanFaMble5jTX/UBQyiv05HsWnwUtY8JrfHy2LWfKwihqMw==",
       "dev": true,
       "requires": {
-        "@octokit/core": "^6.1.2",
-        "@octokit/plugin-paginate-rest": "^11.0.0",
-        "@octokit/plugin-request-log": "^5.1.0",
-        "@octokit/plugin-rest-endpoint-methods": "^13.0.0"
-      },
-      "dependencies": {
-        "@octokit/auth-token": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.1.tgz",
-          "integrity": "sha512-rh3G3wDO8J9wSjfI436JUKzHIxq8NaiL0tVeB2aXmG6p/9859aUOAjA9pmSPNGGZxfwmaJ9ozOJImuNVJdpvbA==",
-          "dev": true
-        },
-        "@octokit/core": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.2.tgz",
-          "integrity": "sha512-hEb7Ma4cGJGEUNOAVmyfdB/3WirWMg5hDuNFVejGEDFqupeOysLc2sG6HJxY2etBp5YQu5Wtxwi020jS9xlUwg==",
-          "dev": true,
-          "requires": {
-            "@octokit/auth-token": "^5.0.0",
-            "@octokit/graphql": "^8.0.0",
-            "@octokit/request": "^9.0.0",
-            "@octokit/request-error": "^6.0.1",
-            "@octokit/types": "^13.0.0",
-            "before-after-hook": "^3.0.2",
-            "universal-user-agent": "^7.0.0"
-          }
-        },
-        "@octokit/endpoint": {
-          "version": "10.1.1",
-          "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.1.tgz",
-          "integrity": "sha512-JYjh5rMOwXMJyUpj028cu0Gbp7qe/ihxfJMLc8VZBMMqSwLgOxDI1911gV4Enl1QSavAQNJcwmwBF9M0VvLh6Q==",
-          "dev": true,
-          "requires": {
-            "@octokit/types": "^13.0.0",
-            "universal-user-agent": "^7.0.2"
-          }
-        },
-        "@octokit/graphql": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.1.1.tgz",
-          "integrity": "sha512-ukiRmuHTi6ebQx/HFRCXKbDlOh/7xEV6QUXaE7MJEKGNAncGI/STSbOkl12qVXZrfZdpXctx5O9X1AIaebiDBg==",
-          "dev": true,
-          "requires": {
-            "@octokit/request": "^9.0.0",
-            "@octokit/types": "^13.0.0",
-            "universal-user-agent": "^7.0.0"
-          }
-        },
-        "@octokit/openapi-types": {
-          "version": "22.2.0",
-          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
-          "integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
-          "dev": true
-        },
-        "@octokit/plugin-request-log": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-5.3.0.tgz",
-          "integrity": "sha512-FiGcyjdtYPlr03ExBk/0ysIlEFIFGJQAVoPPMxL19B24bVSEiZQnVGBunNtaAF1YnvE/EFoDpXmITtRnyCiypQ==",
-          "dev": true,
-          "requires": {}
-        },
-        "@octokit/request": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.1.tgz",
-          "integrity": "sha512-pyAguc0p+f+GbQho0uNetNQMmLG1e80WjkIaqqgUkihqUp0boRU6nKItXO4VWnr+nbZiLGEyy4TeKRwqaLvYgw==",
-          "dev": true,
-          "requires": {
-            "@octokit/endpoint": "^10.0.0",
-            "@octokit/request-error": "^6.0.1",
-            "@octokit/types": "^13.1.0",
-            "universal-user-agent": "^7.0.2"
-          }
-        },
-        "@octokit/request-error": {
-          "version": "6.1.1",
-          "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.1.tgz",
-          "integrity": "sha512-1mw1gqT3fR/WFvnoVpY/zUM2o/XkMs/2AszUUG9I69xn0JFLv6PGkPhNk5lbfvROs79wiS0bqiJNxfCZcRJJdg==",
-          "dev": true,
-          "requires": {
-            "@octokit/types": "^13.0.0"
-          }
-        },
-        "@octokit/types": {
-          "version": "13.5.0",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.5.0.tgz",
-          "integrity": "sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==",
-          "dev": true,
-          "requires": {
-            "@octokit/openapi-types": "^22.2.0"
-          }
-        },
-        "before-after-hook": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
-          "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
-          "dev": true
-        },
-        "universal-user-agent": {
-          "version": "7.0.2",
-          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
-          "integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==",
-          "dev": true
-        }
+        "@octokit/core": "^5.0.2",
+        "@octokit/plugin-paginate-rest": "11.3.1",
+        "@octokit/plugin-request-log": "^4.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "13.2.2"
       }
     },
     "@octokit/types": {
@@ -5931,18 +5697,6 @@
         "webidl2": "^24.2.2"
       },
       "dependencies": {
-        "@octokit/rest": {
-          "version": "20.1.1",
-          "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.1.1.tgz",
-          "integrity": "sha512-MB4AYDsM5jhIHro/dq4ix1iWTLGToIGk6cWF5L6vanFaMble5jTX/UBQyiv05HsWnwUtY8JrfHy2LWfKwihqMw==",
-          "dev": true,
-          "requires": {
-            "@octokit/core": "^5.0.2",
-            "@octokit/plugin-paginate-rest": "11.3.1",
-            "@octokit/plugin-request-log": "^4.0.0",
-            "@octokit/plugin-rest-endpoint-methods": "13.2.2"
-          }
-        },
         "ajv": {
           "version": "8.15.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.15.0.tgz",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@actions/core": "1.10.1",
     "@jsdevtools/npm-publish": "3.1.1",
     "@octokit/plugin-throttling": "^8.1.3",
-    "@octokit/rest": "21.0.0",
+    "@octokit/rest": "20.1.1",
     "@webref/css": "file:packages/css",
     "@webref/elements": "file:packages/elements",
     "@webref/events": "file:packages/events",


### PR DESCRIPTION
Latest version of the dependency is ESM-only and was integrated by mistake: https://github.com/w3c/webref/pull/1264

We should probably switch all code to ESM at some point. In the meantime, this rolls back the version of `@octokit/rest`.