### PR TITLE
Add interface to `error` event in Web Audio API

### DIFF
--- a/tools/amend-event-data.js
+++ b/tools/amend-event-data.js
@@ -434,6 +434,13 @@ const patches = {
       pattern: { type: 'audioprocess' },
       matched: 1,
       change: { interface: 'AudioProcessingEvent' }
+    },
+    {
+      // https://github.com/WebAudio/web-audio-api/issues/2591
+      // https://github.com/WebAudio/web-audio-api/issues/2590
+      pattern: { type: 'error' },
+      matched: 1,
+      change: { interface: 'Event' }
     }
   ],
   'webcodecs': [

--- a/tools/amend-event-data.js
+++ b/tools/amend-event-data.js
@@ -440,7 +440,7 @@ const patches = {
       // https://github.com/WebAudio/web-audio-api/issues/2590
       pattern: { type: 'error' },
       matched: 1,
-      change: { interface: 'Event' }
+      change: { interface: 'ErrorEvent' }
     }
   ],
   'webcodecs': [


### PR DESCRIPTION
Problem raised in:
- https://github.com/WebAudio/web-audio-api/issues/2590 for the actual interface
- https://github.com/WebAudio/web-audio-api/issues/2591 for the syntax