### PR TITLE
Add patch for ed/css/css-mixins.json

### DIFF
--- a/ed/csspatches/css-mixins.json.patch
+++ b/ed/csspatches/css-mixins.json.patch
@@ -1,0 +1,35 @@
+From 2e9d278fb762e1f57bfc999655ad7711162216f6 Mon Sep 17 00:00:00 2001
+From: Francois Daoust <fd@tidoust.net>
+Date: Fri, 12 Jul 2024 08:53:38 +0200
+Subject: [PATCH] Namespace `<combinator>` production to css-mixins
+
+Reported in: https://github.com/w3c/csswg-drafts/issues/10557
+---
+ ed/css/css-mixins.json | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/ed/css/css-mixins.json b/ed/css/css-mixins.json
+index 27a491ee8..d74b55722 100644
+--- a/ed/css/css-mixins.json
++++ b/ed/css/css-mixins.json
+@@ -65,7 +65,7 @@
+       "value": "angle | color | custom-ident | image | integer | length | length-percentage | number | percentage | resolution | string | time | url | transform-function"
+     },
+     {
+-      "name": "<combinator>",
++      "name": "<mixins-combinator>",
+       "href": "https://drafts.csswg.org/css-mixins-1/#typedef-combinator",
+       "type": "type",
+       "value": "'|'"
+@@ -92,7 +92,7 @@
+       "name": "<syntax>",
+       "href": "https://drafts.csswg.org/css-mixins-1/#typedef-syntax",
+       "type": "type",
+-      "value": "'*' | <syntax-component> [ <combinator> <syntax-component> ]+"
++      "value": "'*' | <syntax-component> [ <mixins-combinator> <syntax-component> ]+"
+     }
+   ],
+   "warnings": [
+-- 
+2.42.0.windows.2
+


### PR DESCRIPTION
I'm not sure what approach we actually want to take here. This namespaces the `<combinator>` production to css-mixins because that's easy to do while the spec gets fixed. We might prefer to drop the problematic constructs altogether. Or simply to discard the extract for now since it did not exist before (as suggested in #1055).