### PR TITLE
Update issue reference in CSS patch for css-gcpm

### DIFF
--- a/ed/csspatches/css-gcpm.json.patch
+++ b/ed/csspatches/css-gcpm.json.patch
@@ -3,8 +3,8 @@ From: Francois Daoust <fd@tidoust.net>
 Date: Tue, 30 Jan 2024 09:33:39 +0100
 Subject: [PATCH] Rollback definition of :nth() to please parser
 
-Rolling back pending support in CSSTree for `<an+b>` or some other resolution:
-https://github.com/csstree/csstree/issues/263
+Rolling back pending syntax update for `<an+b>` in CSS Syntax spec:
+https://github.com/w3c/csswg-drafts/pull/9480
 
 Rollback is partial, keeping the `:nth` prefixing.
 ---


### PR DESCRIPTION
Issue was closed in CSSTree project as plan is to change the syntax in CSS Syntax instead.
This is meant to replace #1331.

Side note: we don't need a patch on CSS Syntax because `<an+b>` is the `name` of the construct and not its `value`, and our tests only check that values can be parsed with CSSTree. Now that I think about it, that's probably an oversight, the guarantee should extend to names as well: if the names can't be parsed, they cannot be used as values in any case. I'll propose to refine the test separately (testing locally, `<an+b>` would be the only problematic name).