### PR TITLE
Update Ink Enhancement patch

### DIFF
--- a/ed/idlpatches/ink-enhancement.idl.patch
+++ b/ed/idlpatches/ink-enhancement.idl.patch
@@ -4,6 +4,7 @@ Date: Tue, 7 Sep 2021 16:52:30 +0200
 Subject: [PATCH] Add missing Exposed and fix nullable dictionary argument
 
 https://github.com/WICG/ink-enhancement/pull/32
+https://github.com/WICG/ink-enhancement/pull/37
 ---
  ed/idl/ink-enhancement.idl | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)
@@ -18,7 +19,7 @@ index a20729056..660e2254c 100644
  
 +[Exposed=Window]
  interface Ink {
-     Promise<InkPresenter> requestPresenter(
+     Promise<DelegatedInkTrailPresenter> requestPresenter(
 -        optional InkPresenterParam? param = null);
 +        optional InkPresenterParam param = {});
  };


### PR DESCRIPTION
Also link to newly opened PR to automate publication in the repository, which should get us back on our feet and allow us to drop the patch altogether.

(CI tests will fail due to another unrelated IDL failure)