### PR TITLE
Add patch for ed/idl/private-aggregation-api.idl

### DIFF
--- a/ed/idlpatches/private-aggregation-api.idl.patch
+++ b/ed/idlpatches/private-aggregation-api.idl.patch
@@ -1,0 +1,52 @@
+From 25495dd508439d1e942b1519ac08f7f576491f8b Mon Sep 17 00:00:00 2001
+From: Francois Daoust <fd@tidoust.net>
+Date: Fri, 1 Nov 2024 08:52:00 +0100
+Subject: [PATCH] Drop interfaces now integrated in Turtledove
+
+Pending PR:
+https://github.com/patcg-individual-drafts/private-aggregation-api/pull/166
+---
+ ed/idl/private-aggregation-api.idl | 30 ------------------------------
+ 1 file changed, 30 deletions(-)
+
+diff --git a/ed/idl/private-aggregation-api.idl b/ed/idl/private-aggregation-api.idl
+index cee17c63f..c0ee78e0c 100644
+--- a/ed/idl/private-aggregation-api.idl
++++ b/ed/idl/private-aggregation-api.idl
+@@ -41,33 +41,3 @@ partial interface PrivateAggregation {
+   undefined contributeToHistogramOnEvent(
+       DOMString event, PAExtendedHistogramContribution contribution);
+ };
+-
+-dictionary AuctionReportBuyersConfig {
+-  required bigint bucket;
+-  required double scale;
+-};
+-
+-dictionary AuctionReportBuyerDebugModeConfig {
+-  boolean enabled = false;
+-
+-  // Must only be provided if `enabled` is true.
+-  bigint? debugKey;
+-};
+-
+-partial dictionary AuctionAdConfig {
+-  sequence<bigint> auctionReportBuyerKeys;
+-  record<DOMString, AuctionReportBuyersConfig> auctionReportBuyers;
+-  AuctionReportBuyerDebugModeConfig auctionReportBuyerDebugModeConfig;
+-};
+-
+-dictionary ProtectedAudiencePrivateAggregationConfig {
+-  USVString aggregationCoordinatorOrigin;
+-};
+-
+-partial dictionary AuctionAdConfig {
+-  ProtectedAudiencePrivateAggregationConfig privateAggregationConfig;
+-};
+-
+-partial dictionary AuctionAdInterestGroup {
+-  ProtectedAudiencePrivateAggregationConfig privateAggregationConfig;
+-};
+-- 
+2.37.1.windows.1
+


### PR DESCRIPTION
Drop interfaces now integrated in Turtledove.

Note: that won't be enough to turn all CI tests green (CSS definitions also need to be fixed).