### PR TITLE
Update patch for ed/idl/private-aggregation-api.idl

### DIFF
--- a/ed/idlpatches/private-aggregation-api.idl.patch
+++ b/ed/idlpatches/private-aggregation-api.idl.patch
@@ -1,22 +1,44 @@
-From 25495dd508439d1e942b1519ac08f7f576491f8b Mon Sep 17 00:00:00 2001
+From 2599ea944dac053b39e34cbda7a208423b3c8ded Mon Sep 17 00:00:00 2001
 From: Francois Daoust <fd@tidoust.net>
-Date: Fri, 1 Nov 2024 08:52:00 +0100
+Date: Sat, 2 Nov 2024 11:21:30 +0100
 Subject: [PATCH] Drop interfaces now integrated in Turtledove
 
 Pending PR:
 https://github.com/patcg-individual-drafts/private-aggregation-api/pull/166
 ---
- ed/idl/private-aggregation-api.idl | 30 ------------------------------
- 1 file changed, 30 deletions(-)
+ ed/idl/private-aggregation-api.idl | 52 ------------------------------
+ 1 file changed, 52 deletions(-)
 
 diff --git a/ed/idl/private-aggregation-api.idl b/ed/idl/private-aggregation-api.idl
-index cee17c63f..c0ee78e0c 100644
+index cee17c63f..c89a4687a 100644
 --- a/ed/idl/private-aggregation-api.idl
 +++ b/ed/idl/private-aggregation-api.idl
-@@ -41,33 +41,3 @@ partial interface PrivateAggregation {
-   undefined contributeToHistogramOnEvent(
-       DOMString event, PAExtendedHistogramContribution contribution);
+@@ -19,55 +19,3 @@ dictionary PAHistogramContribution {
+ dictionary PADebugModeOptions {
+   required bigint debugKey;
  };
+-
+-partial interface InterestGroupScriptRunnerGlobalScope {
+-  readonly attribute PrivateAggregation privateAggregation;
+-};
+-
+-dictionary PASignalValue {
+-  required DOMString baseValue;
+-  double scale;
+-  (bigint or long) offset;
+-};
+-
+-dictionary PAExtendedHistogramContribution {
+-  required (PASignalValue or bigint) bucket;
+-  required (PASignalValue or long) value;
+-  bigint filteringId = 0;
+-};
+-
+-[Exposed=InterestGroupScriptRunnerGlobalScope, SecureContext]
+-partial interface PrivateAggregation {
+-  undefined contributeToHistogramOnEvent(
+-      DOMString event, PAExtendedHistogramContribution contribution);
+-};
 -
 -dictionary AuctionReportBuyersConfig {
 -  required bigint bucket;


### PR DESCRIPTION
Complete interfaces now integrated in Turtledove.

CI tests will pass once this PR *and* #1376 are merged.