### PR TITLE
Adjust webaudio shortname in events patch

### DIFF
--- a/tools/amend-event-data.js
+++ b/tools/amend-event-data.js
@@ -432,12 +432,7 @@ const patches = {
       change: { targets: ['XMLHttpRequest', 'XMLHttpRequestUpload'] }
     }
   ],
-  'webaudio': [
-    {
-      pattern: { type: 'update' },
-      matched: 1,
-      change: { interface: 'AudioRenderCapacityEvent' }
-    },
+  'webaudio-1.1': [
     {
       pattern: { type: 'ended' },
       matched: 1,
@@ -447,13 +442,6 @@ const patches = {
       pattern: { type: 'audioprocess' },
       matched: 1,
       change: { interface: 'AudioProcessingEvent' }
-    },
-    {
-      // https://github.com/WebAudio/web-audio-api/issues/2591
-      // https://github.com/WebAudio/web-audio-api/issues/2590
-      pattern: { type: 'error' },
-      matched: 1,
-      change: { interface: 'ErrorEvent' }
     }
   ],
   'webcodecs': [


### PR DESCRIPTION
Also adjust the patch itself as the `error` event now uses the right syntax and no longer uses the `ErrorEvent` interface in any case.