### PR TITLE
Add IDL patches for Shared Storage and Web Locks to avoid duplication

### DIFF
--- a/ed/idlpatches/shared-storage.idl.patch
+++ b/ed/idlpatches/shared-storage.idl.patch
@@ -1,0 +1,28 @@
+From 0e9b836f6073e971dac39fd0c24bf3f47306216c Mon Sep 17 00:00:00 2001
+From: Francois Daoust <fd@tidoust.net>
+Date: Mon, 16 Dec 2024 15:16:50 +0100
+Subject: [PATCH] Drop monkey patches of Web Locks
+
+Pending integration in Web Locks. No specific issue but patch will fail
+once done.
+---
+ ed/idl/shared-storage.idl | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/ed/idl/shared-storage.idl b/ed/idl/shared-storage.idl
+index 353292fa8..b6863eff8 100644
+--- a/ed/idl/shared-storage.idl
++++ b/ed/idl/shared-storage.idl
+@@ -114,9 +114,3 @@ partial dictionary RequestInit {
+ ] interface SharedStorageWorkletNavigator {};
+ 
+ SharedStorageWorkletNavigator includes NavigatorLocks;
+-
+-[SecureContext, Exposed=(Window,Worker,SharedStorageWorklet)]
+-interface LockManager {};
+-
+-[SecureContext, Exposed=(Window,Worker,SharedStorageWorklet)]
+-interface Lock {};
+-- 
+2.37.1.windows.1
+

--- a/ed/idlpatches/web-locks.idl.patch
+++ b/ed/idlpatches/web-locks.idl.patch
@@ -1,0 +1,36 @@
+From f34f3416f5230132136ff05344a7a9f809f97208 Mon Sep 17 00:00:00 2001
+From: Francois Daoust <fd@tidoust.net>
+Date: Mon, 16 Dec 2024 15:22:46 +0100
+Subject: [PATCH] Expose Web Locks interfaces to SharedStorageWorklet
+
+This integrates the monkey patch made in Shared Storage, pending proper
+integration in Web Locks. No specific issue but patch will fail once done.
+---
+ ed/idl/web-locks.idl | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/ed/idl/web-locks.idl b/ed/idl/web-locks.idl
+index d79e404b9..00648cc3b 100644
+--- a/ed/idl/web-locks.idl
++++ b/ed/idl/web-locks.idl
+@@ -10,7 +10,7 @@ interface mixin NavigatorLocks {
+ Navigator includes NavigatorLocks;
+ WorkerNavigator includes NavigatorLocks;
+ 
+-[SecureContext, Exposed=(Window,Worker)]
++[SecureContext, Exposed=(Window,Worker,SharedStorageWorklet)]
+ interface LockManager {
+   Promise<any> request(DOMString name,
+                        LockGrantedCallback callback);
+@@ -43,7 +43,7 @@ dictionary LockInfo {
+   DOMString clientId;
+ };
+ 
+-[SecureContext, Exposed=(Window,Worker)]
++[SecureContext, Exposed=(Window,Worker,SharedStorageWorklet)]
+ interface Lock {
+   readonly attribute DOMString name;
+   readonly attribute LockMode mode;
+-- 
+2.37.1.windows.1
+


### PR DESCRIPTION
The Shared Storage spec is clear that it is monkey patching Web Locks but cannot do it without duplicating the IDL since there's no way to extend the exposure surface of an interface defined elsewhere.