### PR TITLE
Add patch for ed/css/css-gaps.json

### DIFF
--- a/ed/csspatches/css-gaps.json.patch
+++ b/ed/csspatches/css-gaps.json.patch
@@ -1,0 +1,31 @@
+From 39e6c07ed8e6b6c29aee9c1f50bd19769bbfbcde Mon Sep 17 00:00:00 2001
+From: Francois Daoust <fd@tidoust.net>
+Date: Tue, 17 Dec 2024 08:14:18 +0100
+Subject: [PATCH] Drop definition of `repeat()` function
+
+The definition duplicates that in CSS Grid and it's not clear that is intended:
+https://github.com/w3c/csswg-drafts/issues/11385
+---
+ ed/css/css-gaps.json | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/ed/css/css-gaps.json b/ed/css/css-gaps.json
+index 134c3a09c..8eee3d090 100644
+--- a/ed/css/css-gaps.json
++++ b/ed/css/css-gaps.json
+@@ -457,12 +457,6 @@
+       "type": "type",
+       "value": "repeat( auto , [ <line-width> ]+ )"
+     },
+-    {
+-      "name": "repeat()",
+-      "prose": "Such a list may contain repeat() notations. Similar to CSS Grid Layout 1 § 7.2.3 Repeating Rows and Columns: the repeat() notation, these notations allow a series of gap decorations that exhibit a recurring pattern to be written in a more compact form.",
+-      "href": "https://drafts.csswg.org/css-gaps-1/#funcdef-repeat",
+-      "type": "function"
+-    },
+     {
+       "name": "<gap-rule-list>",
+       "href": "https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule-list",
+-- 
+2.37.1.windows.1
+

--- a/tools/drop-css-property-duplicates.js
+++ b/tools/drop-css-property-duplicates.js
@@ -86,6 +86,10 @@ const supersededBy = {
   // https://drafts.csswg.org/css-color-hdr/#color-function
   'css-color': 'css-color-hdr',
 
+  // CSS Gap Decorations supersedes CSS Multi-column layout
+  // https://drafts.csswg.org/css-gaps-1/#color-style-width
+  'css-multicol': 'css-gaps',
+
   // See note in https://svgwg.org/specs/strokes/#sotd
   // "In the future, this specification will supersede the SVG 2 Stroke
   // definition, however at this time the SVG 2 Stroke definition must be


### PR DESCRIPTION
Drops duplication of `repeat()` pending clarification of intent upstream.

Note: this PR includes #1410.