### PR TITLE
Adjust events patch for Web Bluetooth

### DIFF
--- a/tools/amend-event-data.js
+++ b/tools/amend-event-data.js
@@ -447,6 +447,13 @@ const patches = {
       change: { targets: ['XMLHttpRequest', 'XMLHttpRequestUpload'] }
     }
   ],
+  'web-bluetooth': [
+    {
+      pattern: { type: /^(advertisementreceived|gattserverdisconnected)$/ },
+      matched: 2,
+      change: { targets: ['BluetoothDevice'], bubbles: true }
+    }
+  ],
   'webaudio-1.1': [
     {
       pattern: { type: 'ended' },


### PR DESCRIPTION
The target interface of `advertisementreceived` and `gattserverdisconnected` is a mixin, actual target is `BluetoothDevice`. Also, the events bubble, which wasn't properly captured.