### PR TITLE
Adjust clean jobs for CDDL extracts

### DIFF
--- a/tools/clean-abandoned-files.js
+++ b/tools/clean-abandoned-files.js
@@ -15,7 +15,10 @@ function checkDir(path, index) {
   const dir = fs.readdirSync(path);
   for (let filename of dir) {
     const subdir = path.split("/")[1];
-    if (!index.results.find(spec => spec[subdir] === subdir + "/" + filename)) {
+    const fullname = subdir + "/" + filename
+    if (!index.results.find(spec =>
+          spec[subdir] === fullname ||
+          spec[subdir]?.find(extract => extract.file === fullname))) {
       fs.unlinkSync(path + "/" + filename);
     }
   }

--- a/tools/clean-dropped-specs-files.js
+++ b/tools/clean-dropped-specs-files.js
@@ -26,7 +26,11 @@ async function cleanExtractFolder(folder, crawlResults) {
   for (const filename of dir) {
     const specname = path.basename(filename, path.extname(filename));
     const spec = crawlResults
-      .find(s => s.shortname === specname || s.series?.shortname === specname);
+      .find(s => s.shortname === specname ||
+        s.series?.shortname === specname ||
+        // CDDL extracts may end with CDDL module name
+        s.shortname.startsWith(specname + '-')
+      );
     if (!spec) {
       const fileToDrop = path.join(folder, filename);
       await fs.unlink(fileToDrop);


### PR DESCRIPTION
The clean jobs did not expect multiple extracts per property and would happily have dropped CDDL extracts.