### PR TITLE
Add a validation guarantee to curated CDDL extracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ Data curation brings the following guarantees.
 
 ### CDDL extracts
 
-The CDDL extracts currently come with no guarantee whatsoever and may be invalid. Tracked in [#1417](https://github.com/w3c/webref/issues/1417).
+- All CDDL files pass CDDL analysis by the version of [Strudy](https://github.com/w3c/strudy) referenced in `package.json`. Said differently, all CDDL files can be parsed by the version of [cddlparser](https://github.com/tidoust/cddlparser) referenced by Strudy.
+
+The CDDL extracts are not released in an NPM package for the time being.
 
 ## Known consumers
 

--- a/ed/cddlpatches/README.md
+++ b/ed/cddlpatches/README.md
@@ -1,0 +1,5 @@
+# CDDL patches
+
+These are patches applied to the CDDL extracts scraped from specs. These patches can break as specs are updated and thus need ongoing maintenance.
+
+For details on how to create and update patches, please see the [Web IDL patches documentation](../idlpatches/README.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "mocha": "11.0.1",
         "reffy": "18.1.2",
         "rimraf": "6.0.1",
-        "strudy": "^3.0.2",
+        "strudy": "^3.1.1",
         "webidl2": "24.4.1"
       },
       "engines": {
@@ -485,81 +485,6 @@
       "optional": true,
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@puppeteer/browsers": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.4.1.tgz",
-      "integrity": "sha512-0kdAbmic3J09I6dT8e9vE2JOCSt13wHCW5x/ly8TSt2bDtuIWe2TgLZZDHdcziw9AVCzflMAXCrVyRIhIs44Ng==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.3.7",
-        "extract-zip": "^2.0.1",
-        "progress": "^2.0.3",
-        "proxy-agent": "^6.4.0",
-        "semver": "^7.6.3",
-        "tar-fs": "^3.0.6",
-        "unbzip2-stream": "^1.4.3",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "browsers": "lib/cjs/main-cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
@@ -1116,24 +1041,17 @@
       }
     },
     "node_modules/cssstyle": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.0.1.tgz",
-      "integrity": "sha512-8ZYiJ3A/3OkDd093CBT/0UKDWry7ak4BdPTFP2+QEP7cmhouyq/Up709ASSj2cK02BbZiMgk7kYjZNS4QP5qrQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.1.0.tgz",
+      "integrity": "sha512-h66W1URKpBS5YMI/V8PyXvTMFT8SupJ1IzoIV8IeBC/ji8WVmrO8dGlTi+2dh6whmdk6BiKJLD/ZBkhWbcg6nA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "rrweb-cssom": "^0.6.0"
+        "rrweb-cssom": "^0.7.1"
       },
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/cssstyle/node_modules/rrweb-cssom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
-      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.2",
@@ -1357,6 +1275,7 @@
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-extendable": "^0.1.0"
       },
@@ -1568,9 +1487,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1710,6 +1629,7 @@
       "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
       "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "js-yaml": "^3.13.1",
         "kind-of": "^6.0.2",
@@ -1725,6 +1645,7 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
@@ -1734,6 +1655,7 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -1902,6 +1824,7 @@
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2019,13 +1942,13 @@
       "dev": true
     },
     "node_modules/jsdom": {
-      "version": "25.0.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.0.tgz",
-      "integrity": "sha512-OhoFVT59T7aEq75TVw9xxEfkXgacpqAhQaYgP9y/fDqWQCMB/b1H66RfmPm/MaeaAIU9nDwMOVTlPN51+ao6CQ==",
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cssstyle": "^4.0.1",
+        "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
         "decimal.js": "^10.4.3",
         "form-data": "^4.0.0",
@@ -2038,7 +1961,7 @@
         "rrweb-cssom": "^0.7.1",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.1.4",
+        "tough-cookie": "^5.0.0",
         "w3c-xmlserializer": "^5.0.0",
         "webidl-conversions": "^7.0.0",
         "whatwg-encoding": "^3.1.1",
@@ -2076,6 +1999,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2298,9 +2222,9 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.12",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.12.tgz",
-      "integrity": "sha512-qXDmcVlZV4XRtKFzddidpfVP4oMSGhga+xdMc25mv8kaLUHtgzCDhUxkrN8exkGdTlLNaXj7CV3GtON7zuGZ+w==",
+      "version": "2.2.16",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.16.tgz",
+      "integrity": "sha512-F1I/bimDpj3ncaNDhfyMWuFqmQDBwDB0Fogc2qpL3BWvkQteFD/8BzWuIRl83rq0DXfm8SGt/HFhLXZyljTXcQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2412,13 +2336,13 @@
       }
     },
     "node_modules/parse5": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
+      "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "entities": "^4.4.0"
+        "entities": "^4.5.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -2530,13 +2454,6 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true
-    },
-    "node_modules/psl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/pump": {
       "version": "3.0.2",
@@ -2772,12 +2689,18 @@
         "node": ">=12"
       }
     },
-    "node_modules/querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+    "node_modules/pyodide": {
+      "version": "0.26.4",
+      "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.26.4.tgz",
+      "integrity": "sha512-z2CHsjVlhhJi5tYBF0AYAfNEPo3zq/z+xOpFtk1tweJkRaTqU4UK/7pLvo8DBU2VDPH31vB3pSI+8fnoqrVrFg==",
       "dev": true,
-      "license": "MIT"
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ws": "^8.5.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/queue-tick": {
       "version": "1.0.1",
@@ -2845,13 +2768,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -3014,6 +2930,7 @@
       "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
       "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "extend-shallow": "^2.0.1",
         "kind-of": "^6.0.0"
@@ -3140,7 +3057,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/streamx": {
       "version": "2.20.2",
@@ -3215,6 +3133,7 @@
       "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
       "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3253,18 +3172,20 @@
       }
     },
     "node_modules/strudy": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/strudy/-/strudy-3.0.2.tgz",
-      "integrity": "sha512-IBW4NhE9fFkViLIk3MaBE34PsTR8VlyGhhP9B5pAJ8lT7BvYEcNp57lCQctN20z/Js21PmKpYd5RwdWZ6BrX7w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strudy/-/strudy-3.1.1.tgz",
+      "integrity": "sha512-IU4dvcR5i4foYd5E/Ylm/R61wK3HeVr2MtTLyaepcBs490ElQqp2sSqGjWFpmJVGL/4Heh0arKG6E/DZeT3a/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",
         "@octokit/plugin-throttling": "^9.3.1",
         "@octokit/rest": "^21.0.1",
         "commander": "12.1.0",
         "gray-matter": "^4.0.3",
-        "jsdom": "^25.0.0",
-        "reffy": "^17.1.1",
+        "jsdom": "^25.0.1",
+        "pyodide": "^0.26.4",
+        "reffy": "^18.0.1",
         "semver": "^7.3.5",
         "webidl2": "^24.2.2"
       },
@@ -3274,72 +3195,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/strudy/node_modules/puppeteer": {
-      "version": "23.8.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-23.8.0.tgz",
-      "integrity": "sha512-MFWDMWoCcOpwNwQIjA9gPKWrEUbj8bLCzkK56w5lZPMUT6wK4FfpgOEPxKffVmXEMYMZzgcjxzqy15b/Q1ibaw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@puppeteer/browsers": "2.4.1",
-        "chromium-bidi": "0.8.0",
-        "cosmiconfig": "^9.0.0",
-        "devtools-protocol": "0.0.1367902",
-        "puppeteer-core": "23.8.0",
-        "typed-query-selector": "^2.12.0"
-      },
-      "bin": {
-        "puppeteer": "lib/cjs/puppeteer/node/cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/strudy/node_modules/puppeteer-core": {
-      "version": "23.8.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.8.0.tgz",
-      "integrity": "sha512-c2ymGN2M//We7pC+JhP2dE/g4+qnT89BO+EMSZyJmecN3DN6RNqErA7eH7DrWoNIcU75r2nP4VHa4pswAL6NVg==",
-      "dev": true,
-      "dependencies": {
-        "@puppeteer/browsers": "2.4.1",
-        "chromium-bidi": "0.8.0",
-        "debug": "^4.3.7",
-        "devtools-protocol": "0.0.1367902",
-        "typed-query-selector": "^2.12.0",
-        "ws": "^8.18.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/strudy/node_modules/reffy": {
-      "version": "17.2.10",
-      "resolved": "https://registry.npmjs.org/reffy/-/reffy-17.2.10.tgz",
-      "integrity": "sha512-qWt2OkxfcOWnr0Fy3E10qhNODaAt3vy7+Avq1GFIwCNkAG9u2ff0NcS23sJ4X34duJnUgPzvl1FTLwWEJAaEeQ==",
-      "dev": true,
-      "dependencies": {
-        "ajv": "8.17.1",
-        "ajv-formats": "3.0.1",
-        "commander": "12.1.0",
-        "fetch-filecache-for-crawling": "5.1.1",
-        "puppeteer": "23.8.0",
-        "semver": "^7.3.5",
-        "web-specs": "3.26.0",
-        "webidl2": "24.4.1"
-      },
-      "bin": {
-        "reffy": "reffy.js"
-      },
-      "engines": {
-        "node": ">=20.12.1"
-      }
-    },
-    "node_modules/strudy/node_modules/web-specs": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/web-specs/-/web-specs-3.26.0.tgz",
-      "integrity": "sha512-LijSDij82IGvjsdDuWjGcZRc/vy5zkzUKUZngZRKXjFhcoZBg+wybuov8HTClxuLo/z5bFq/WlkwyC3lT8EcyA==",
-      "dev": true
     },
     "node_modules/supports-color": {
       "version": "8.1.1",
@@ -3426,6 +3281,26 @@
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
+    "node_modules/tldts": {
+      "version": "6.1.69",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.69.tgz",
+      "integrity": "sha512-Oh/CqRQ1NXNY7cy9NkTPUauOWiTro0jEYZTioGbOmcQh6EC45oribyIMJp0OJO3677r13tO6SKdWoGZUx2BDFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.69"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.69",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.69.tgz",
+      "integrity": "sha512-nygxy9n2PBUFQUtAXAc122gGo+04/j5qr5TGQFZTHafTKYvmARVXt2cA5rgero2/dnXUfkdPtiJoKmrd3T+wdA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3439,29 +3314,16 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
-      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.0.0.tgz",
+      "integrity": "sha512-FRKsF7cz96xIIeMZ82ehjC3xW2E+O2+v11udrDYewUbszngYhsGa8z6YUMMzO9QJZzzyd0nGGXnML/TReX6W8Q==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.2.0",
-        "url-parse": "^1.5.3"
+        "tldts": "^6.1.32"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tough-cookie/node_modules/universalify": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -3553,17 +3415,6 @@
       "license": "ISC",
       "peer": true
     },
-    "node_modules/url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
-      }
-    },
     "node_modules/urlpattern-polyfill": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
@@ -3632,9 +3483,9 @@
       }
     },
     "node_modules/whatwg-url": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.0.0.tgz",
-      "integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.1.0.tgz",
+      "integrity": "sha512-jlf/foYIKywAt3x/XWKZ/3rz8OSJPiWktjmk891alJUEjiVxKX9LEO92qH3hv4aJ0mN3MWPvGMCy8jQi95xK4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4236,62 +4087,6 @@
       "dev": true,
       "optional": true
     },
-    "@puppeteer/browsers": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.4.1.tgz",
-      "integrity": "sha512-0kdAbmic3J09I6dT8e9vE2JOCSt13wHCW5x/ly8TSt2bDtuIWe2TgLZZDHdcziw9AVCzflMAXCrVyRIhIs44Ng==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.3.7",
-        "extract-zip": "^2.0.1",
-        "progress": "^2.0.3",
-        "proxy-agent": "^6.4.0",
-        "semver": "^7.6.3",
-        "tar-fs": "^3.0.6",
-        "unbzip2-stream": "^1.4.3",
-        "yargs": "^17.7.2"
-      },
-      "dependencies": {
-        "cliui": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-          "dev": true,
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.1",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
-        "semver": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-          "dev": true
-        },
-        "yargs": {
-          "version": "17.7.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-          "dev": true,
-          "requires": {
-            "cliui": "^8.0.1",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.3",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^21.1.1"
-          }
-        },
-        "yargs-parser": {
-          "version": "21.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-          "dev": true
-        }
-      }
-    },
     "@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
@@ -4707,20 +4502,12 @@
       }
     },
     "cssstyle": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.0.1.tgz",
-      "integrity": "sha512-8ZYiJ3A/3OkDd093CBT/0UKDWry7ak4BdPTFP2+QEP7cmhouyq/Up709ASSj2cK02BbZiMgk7kYjZNS4QP5qrQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.1.0.tgz",
+      "integrity": "sha512-h66W1URKpBS5YMI/V8PyXvTMFT8SupJ1IzoIV8IeBC/ji8WVmrO8dGlTi+2dh6whmdk6BiKJLD/ZBkhWbcg6nA==",
       "dev": true,
       "requires": {
-        "rrweb-cssom": "^0.6.0"
-      },
-      "dependencies": {
-        "rrweb-cssom": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
-          "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
-          "dev": true
-        }
+        "rrweb-cssom": "^0.7.1"
       }
     },
     "data-uri-to-buffer": {
@@ -5021,9 +4808,9 @@
       }
     },
     "form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
       "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
@@ -5348,12 +5135,12 @@
       "dev": true
     },
     "jsdom": {
-      "version": "25.0.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.0.tgz",
-      "integrity": "sha512-OhoFVT59T7aEq75TVw9xxEfkXgacpqAhQaYgP9y/fDqWQCMB/b1H66RfmPm/MaeaAIU9nDwMOVTlPN51+ao6CQ==",
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "requires": {
-        "cssstyle": "^4.0.1",
+        "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
         "decimal.js": "^10.4.3",
         "form-data": "^4.0.0",
@@ -5366,7 +5153,7 @@
         "rrweb-cssom": "^0.7.1",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.1.4",
+        "tough-cookie": "^5.0.0",
         "w3c-xmlserializer": "^5.0.0",
         "webidl-conversions": "^7.0.0",
         "whatwg-encoding": "^3.1.1",
@@ -5556,9 +5343,9 @@
       "dev": true
     },
     "nwsapi": {
-      "version": "2.2.12",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.12.tgz",
-      "integrity": "sha512-qXDmcVlZV4XRtKFzddidpfVP4oMSGhga+xdMc25mv8kaLUHtgzCDhUxkrN8exkGdTlLNaXj7CV3GtON7zuGZ+w==",
+      "version": "2.2.16",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.16.tgz",
+      "integrity": "sha512-F1I/bimDpj3ncaNDhfyMWuFqmQDBwDB0Fogc2qpL3BWvkQteFD/8BzWuIRl83rq0DXfm8SGt/HFhLXZyljTXcQ==",
       "dev": true
     },
     "once": {
@@ -5642,12 +5429,12 @@
       }
     },
     "parse5": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
+      "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
       "dev": true,
       "requires": {
-        "entities": "^4.4.0"
+        "entities": "^4.5.0"
       }
     },
     "path-exists": {
@@ -5732,12 +5519,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
-    },
-    "psl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
       "dev": true
     },
     "pump": {
@@ -5916,11 +5697,14 @@
         }
       }
     },
-    "querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "dev": true
+    "pyodide": {
+      "version": "0.26.4",
+      "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.26.4.tgz",
+      "integrity": "sha512-z2CHsjVlhhJi5tYBF0AYAfNEPo3zq/z+xOpFtk1tweJkRaTqU4UK/7pLvo8DBU2VDPH31vB3pSI+8fnoqrVrFg==",
+      "dev": true,
+      "requires": {
+        "ws": "^8.5.0"
+      }
     },
     "queue-tick": {
       "version": "1.0.1",
@@ -5972,12 +5756,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true
-    },
-    "requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true
     },
     "resolve-from": {
@@ -6251,9 +6029,9 @@
       }
     },
     "strudy": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/strudy/-/strudy-3.0.2.tgz",
-      "integrity": "sha512-IBW4NhE9fFkViLIk3MaBE34PsTR8VlyGhhP9B5pAJ8lT7BvYEcNp57lCQctN20z/Js21PmKpYd5RwdWZ6BrX7w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strudy/-/strudy-3.1.1.tgz",
+      "integrity": "sha512-IU4dvcR5i4foYd5E/Ylm/R61wK3HeVr2MtTLyaepcBs490ElQqp2sSqGjWFpmJVGL/4Heh0arKG6E/DZeT3a/w==",
       "dev": true,
       "requires": {
         "@actions/core": "^1.10.0",
@@ -6261,62 +6039,11 @@
         "@octokit/rest": "^21.0.1",
         "commander": "12.1.0",
         "gray-matter": "^4.0.3",
-        "jsdom": "^25.0.0",
-        "reffy": "^17.1.1",
+        "jsdom": "^25.0.1",
+        "pyodide": "^0.26.4",
+        "reffy": "^18.0.1",
         "semver": "^7.3.5",
         "webidl2": "^24.2.2"
-      },
-      "dependencies": {
-        "puppeteer": {
-          "version": "23.8.0",
-          "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-23.8.0.tgz",
-          "integrity": "sha512-MFWDMWoCcOpwNwQIjA9gPKWrEUbj8bLCzkK56w5lZPMUT6wK4FfpgOEPxKffVmXEMYMZzgcjxzqy15b/Q1ibaw==",
-          "dev": true,
-          "requires": {
-            "@puppeteer/browsers": "2.4.1",
-            "chromium-bidi": "0.8.0",
-            "cosmiconfig": "^9.0.0",
-            "devtools-protocol": "0.0.1367902",
-            "puppeteer-core": "23.8.0",
-            "typed-query-selector": "^2.12.0"
-          }
-        },
-        "puppeteer-core": {
-          "version": "23.8.0",
-          "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.8.0.tgz",
-          "integrity": "sha512-c2ymGN2M//We7pC+JhP2dE/g4+qnT89BO+EMSZyJmecN3DN6RNqErA7eH7DrWoNIcU75r2nP4VHa4pswAL6NVg==",
-          "dev": true,
-          "requires": {
-            "@puppeteer/browsers": "2.4.1",
-            "chromium-bidi": "0.8.0",
-            "debug": "^4.3.7",
-            "devtools-protocol": "0.0.1367902",
-            "typed-query-selector": "^2.12.0",
-            "ws": "^8.18.0"
-          }
-        },
-        "reffy": {
-          "version": "17.2.10",
-          "resolved": "https://registry.npmjs.org/reffy/-/reffy-17.2.10.tgz",
-          "integrity": "sha512-qWt2OkxfcOWnr0Fy3E10qhNODaAt3vy7+Avq1GFIwCNkAG9u2ff0NcS23sJ4X34duJnUgPzvl1FTLwWEJAaEeQ==",
-          "dev": true,
-          "requires": {
-            "ajv": "8.17.1",
-            "ajv-formats": "3.0.1",
-            "commander": "12.1.0",
-            "fetch-filecache-for-crawling": "5.1.1",
-            "puppeteer": "23.8.0",
-            "semver": "^7.3.5",
-            "web-specs": "3.26.0",
-            "webidl2": "24.4.1"
-          }
-        },
-        "web-specs": {
-          "version": "3.26.0",
-          "resolved": "https://registry.npmjs.org/web-specs/-/web-specs-3.26.0.tgz",
-          "integrity": "sha512-LijSDij82IGvjsdDuWjGcZRc/vy5zkzUKUZngZRKXjFhcoZBg+wybuov8HTClxuLo/z5bFq/WlkwyC3lT8EcyA==",
-          "dev": true
-        }
       }
     },
     "supports-color": {
@@ -6391,6 +6118,21 @@
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
+    "tldts": {
+      "version": "6.1.69",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.69.tgz",
+      "integrity": "sha512-Oh/CqRQ1NXNY7cy9NkTPUauOWiTro0jEYZTioGbOmcQh6EC45oribyIMJp0OJO3677r13tO6SKdWoGZUx2BDFw==",
+      "dev": true,
+      "requires": {
+        "tldts-core": "^6.1.69"
+      }
+    },
+    "tldts-core": {
+      "version": "6.1.69",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.69.tgz",
+      "integrity": "sha512-nygxy9n2PBUFQUtAXAc122gGo+04/j5qr5TGQFZTHafTKYvmARVXt2cA5rgero2/dnXUfkdPtiJoKmrd3T+wdA==",
+      "dev": true
+    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -6401,23 +6143,12 @@
       }
     },
     "tough-cookie": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
-      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.0.0.tgz",
+      "integrity": "sha512-FRKsF7cz96xIIeMZ82ehjC3xW2E+O2+v11udrDYewUbszngYhsGa8z6YUMMzO9QJZzzyd0nGGXnML/TReX6W8Q==",
       "dev": true,
       "requires": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.2.0",
-        "url-parse": "^1.5.3"
-      },
-      "dependencies": {
-        "universalify": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-          "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-          "dev": true
-        }
+        "tldts": "^6.1.32"
       }
     },
     "tr46": {
@@ -6494,16 +6225,6 @@
       "dev": true,
       "peer": true
     },
-    "url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dev": true,
-      "requires": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
-      }
-    },
     "urlpattern-polyfill": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
@@ -6553,9 +6274,9 @@
       "dev": true
     },
     "whatwg-url": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.0.0.tgz",
-      "integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.1.0.tgz",
+      "integrity": "sha512-jlf/foYIKywAt3x/XWKZ/3rz8OSJPiWktjmk891alJUEjiVxKX9LEO92qH3hv4aJ0mN3MWPvGMCy8jQi95xK4w==",
       "dev": true,
       "requires": {
         "tr46": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "mocha": "11.0.1",
     "reffy": "18.1.2",
     "rimraf": "6.0.1",
-    "strudy": "^3.0.2",
+    "strudy": "^3.1.1",
     "webidl2": "24.4.1"
   },
   "scripts": {

--- a/test/cddl/all.js
+++ b/test/cddl/all.js
@@ -1,0 +1,36 @@
+/**
+ * Test individual CDDL extracts.
+ * 
+ * The tests run against the curated view of the extracts.
+ */
+
+import { strict as assert } from 'node:assert';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadJSON } from '../../tools/utils.js';
+import { expandCrawlResult } from 'reffy';
+import { study } from 'strudy';
+
+const scriptPath = path.dirname(fileURLToPath(import.meta.url));
+const curatedFolder = path.join(scriptPath, '..', '..', 'curated');
+
+function writeAnomalies(report) {
+  return 'CDDL anomalies found:\n' +
+    report.map(anomaly => anomaly.content).join('\n');
+}
+
+describe('The curated view of CDDL extracts', function () {
+  // First run may download micropip and cddlparser packages from the net
+  this.timeout(30000);
+
+  it('passes Strudy\'s scrutiny', async function () {
+    const crawlFile = path.join(curatedFolder, 'index.json');
+    let crawl = await loadJSON(crawlFile);
+    crawl = await expandCrawlResult(crawl, curatedFolder);
+
+    const studyOptions = { what: ['cddl'], structure: 'flat' };
+    const report = await study(crawl.results, studyOptions);
+    const results = report.results;
+    assert.equal(results.length, 0, writeAnomalies(results));
+  });
+});

--- a/test/idl/consistency.js
+++ b/test/idl/consistency.js
@@ -33,7 +33,9 @@ const ignorableAnomalies = [
   'incompatiblePartialIdlExposure',
   'singleEnumValue',
   'unexpectedEventHandler',
-  'wrongCaseEnumValue'
+  'wrongCaseEnumValue',
+  'noEvent',
+  'urlType'
 ];
 
 

--- a/tools/apply-patches.js
+++ b/tools/apply-patches.js
@@ -27,6 +27,14 @@ async function applyPatches(rawFolder, outputFolder, type) {
 
   const packages = [
     {
+      name: 'cddl',
+      srcDir: path.join(rawFolder, 'cddl'),
+      dstDir: path.join(outputFolder, 'cddl'),
+      dstDirForCli: [outputFolder, 'cddl'].join('/'),
+      patchDir: path.join(rawFolder, 'cddlpatches'),
+      fileExt: 'cddl'
+    },
+    {
       name: 'css',
       srcDir: path.join(rawFolder, 'css'),
       dstDir: path.join(outputFolder, 'css'),

--- a/tools/create-patch.js
+++ b/tools/create-patch.js
@@ -15,21 +15,23 @@ const exec = util.promisify(execCb);
 const execFile = util.promisify(execFileCb);
 
 async function main() {
-  console.log('Check last commit touches one and only one CSS/Elements/IDL file...');
+  console.log('Check last commit touches one and only one CDDL/CSS/Elements/IDL file...');
   const { stdout: diffOut } = await execFile('git', ['diff', '--name-only', 'HEAD', 'HEAD~1']);
   const files = diffOut.split(/[\r\n]/).filter(f => !!f);
   if (files.length !== 1) {
-    throw new Error('Last commit should only touch one CSS/Elements/IDL file');
+    throw new Error('Last commit should only touch one CDDL/CSS/Elements/IDL file');
   }
   const commitFile = files[0];
   if (!commitFile.startsWith('ed/idl/') &&
+      !commitFile.startsWith('ed/cddl/') &&
       !commitFile.startsWith('ed/css/') &&
       !commitFile.startsWith('ed/elements/')) {
-    throw new Error('Last commit did not touch a CSS/Elements/IDL file');
+    throw new Error('Last commit did not touch a CDD/CSS/Elements/IDL file');
   }
   const patchType =
     commitFile.startsWith('ed/idl/') ? 'idl' :
-    commitFile.startsWith('ed/elements/') ? 'elements' : 'css';
+    commitFile.startsWith('ed/elements/') ? 'elements' :
+    commitFile.startsWith('ed/cddl/') ? 'cddl' : 'css';
   const patchFile = commitFile.substring(`ed/${patchType}/`.length);
   console.log('  done');
 

--- a/tools/prepare-curated.js
+++ b/tools/prepare-curated.js
@@ -34,10 +34,10 @@ import { crawlSpecs } from 'reffy';
  * Remove the spec from curation process
 */
 async function removeFromCuration(spec, curatedFolder) {
-  for (const property of ['css', 'elements', 'events', 'idl']) {
+  for (const property of ['cddl', 'css', 'elements', 'events', 'idl']) {
     if (spec[property] &&
         (typeof spec[property] === 'string') &&
-        spec[property].match(/^[^\/]+\/[^\/]+\.(json|idl)$/)) {
+        spec[property].match(/^[^\/]+\/[^\/]+\.(json|idl|cddl)$/)) {
       const filename = path.join(curatedFolder, spec[property]);
       console.log(`Removing ${spec.standing} ${spec.title} from curation: del ${filename}`);
       await fs.unlink(filename);
@@ -58,7 +58,7 @@ async function cleanCrawlOutcome(spec) {
     // Only consider properties that link to an extract
     if (spec[property] &&
         (typeof spec[property] === 'string') &&
-        spec[property].match(/^[^\/]+\/[^\/]+\.(json|idl)$/)) {
+        spec[property].match(/^[^\/]+\/[^\/]+\.(json|idl|cddl)$/)) {
       try {
         await fs.lstat(path.join(curatedFolder, spec[property]));
       }


### PR DESCRIPTION
This leverages CDDL validation in Strudy to provide a validation guarantee to curated CDDL extracts, see #1417.

A `cddlpatches` folder, which will hopefully remain empty, gets added so that we may temporarily patch CDDL extracts when they become invalid.

The PR is ready for review, but CDDL extracts in Webref are invalid for now. CDDL extracts from the permissions spec should become valid with next crawl. CDDL extracts from the at-driver depend on https://github.com/w3c/at-driver/pull/85. I suggest to leave this PR pending until the extracts in Webref become valid, not to have to start with adding patches.