### PR TITLE
Disable AppArmor to run Puppeteer

### DIFF
--- a/.github/workflows/update-ed.yml
+++ b/.github/workflows/update-ed.yml
@@ -7,6 +7,13 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
+    # Starting with Ubuntu 23+, a security feature prevents running Puppeteer
+    # by default. It needs to be disabled. Using the "easiest" option, see:
+    # https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
+    # https://github.com/puppeteer/puppeteer/pull/13196/files
+    - name: Disable AppArmor
+      run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+
     - name: Checkout repo
       uses: actions/checkout@v4
 

--- a/.github/workflows/update-tr.yml
+++ b/.github/workflows/update-tr.yml
@@ -7,6 +7,13 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
+    # Starting with Ubuntu 23+, a security feature prevents running Puppeteer
+    # by default. It needs to be disabled. Using the "easiest" option, see:
+    # https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
+    # https://github.com/puppeteer/puppeteer/pull/13196/files
+    - name: Disable AppArmor
+      run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+
     - name: Checkout repo
       uses: actions/checkout@v4
 


### PR DESCRIPTION
GitHub Actions have switched to Ubuntu 24.x. Disabling AppArmor is (not fantastic but) needed to run Puppeteer.