### PR TITLE
Pin reffy jobs to ubuntu-22.04 for now

### DIFF
--- a/.github/workflows/update-ed.yml
+++ b/.github/workflows/update-ed.yml
@@ -5,7 +5,7 @@ on:
 name: Update ED report
 jobs:
   update:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4

--- a/.github/workflows/update-tr.yml
+++ b/.github/workflows/update-tr.yml
@@ -5,7 +5,7 @@ on:
 name: Update TR report
 jobs:
   update:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4


### PR DESCRIPTION
For puppeteer/chromium sake see https://github.com/puppeteer/puppeteer/issues/12818