### PR TITLE
Fix naming logic when dropping duplicate CSS properties

### DIFF
--- a/tools/drop-css-property-duplicates.js
+++ b/tools/drop-css-property-duplicates.js
@@ -16,7 +16,7 @@ import util from 'node:util';
 import { fileURLToPath } from 'node:url';
 import { execFile as execFileCb } from 'node:child_process';
 import { loadJSON } from './utils.js';
-import { expandCrawlResult } from 'reffy';
+import { expandCrawlResult, isLatestLevelThatPasses } from 'reffy';
 const execFile = util.promisify(execFileCb);
 
 
@@ -247,7 +247,7 @@ async function dropCSSPropertyDuplicates(folder) {
       }
     }, spec.css);
     const json = JSON.stringify(css, null, 2) + '\n';
-    const filename = spec.shortname === spec.series.currentSpecification ?
+    const filename = isLatestLevelThatPasses(spec, index.results, spec => spec.css) ?
       spec.series.shortname :
       spec.shortname
     const pathname = path.join(folder, 'css', filename + '.json');


### PR DESCRIPTION
The script that drops duplicate CSS properties in known superseded specs did not follow the exact same file naming logic as that followed by the crawler. It took for granted that the file had to be the spec's shortname if the spec wasn't the current specification, but the logic followed by the crawler is rather that defined in `isLatestLevelThatPasses`: the latest full level that defines some CSS is the one that provides the series CSS extract.

This nuance had never led to any problem in this part of the code because a spec that defines superseded content typically does not have a "next" level that is not the current level and that keeps on defining the superseded content. Copying the superseded content to a newer level does not make sense, right? Well, that's what `css-multicol-2` currently does.

This update fixes the file naming logic, which should have followed that of the crawler in any case.