### PR TITLE
Also drop wrapping quotes in at-rule values

### DIFF
--- a/tools/drop-css-property-duplicates.js
+++ b/tools/drop-css-property-duplicates.js
@@ -238,7 +238,7 @@ async function dropCSSPropertyDuplicates(folder) {
     if (!spec.css) {
       continue;
     }
-    for (const dfnType of ['properties', 'values']) {
+    for (const dfnType of ['properties', 'values', 'atrules']) {
       for (const prop of spec.css[dfnType]) {
         if (!prop.value) {
           continue;


### PR DESCRIPTION
Missed the fact that css-color-5 also has an occurrence of `''` in the definition of an at-rule...