### PR TITLE
Drop event patch for capturedzoomlevelchange

### DIFF
--- a/tools/amend-event-data.js
+++ b/tools/amend-event-data.js
@@ -277,12 +277,6 @@ const patches = {
       pattern: { type: 'wheel' },
       matched: 1,
       delete: true
-    },
-    // Pending https://github.com/w3c/mediacapture-surface-control/issues/50
-    {
-      pattern: { type: 'capturedzoomlevelchange' },
-      matched: 1,
-      change: { interface: "Event" }
     }
   ],
   'notifications': [


### PR DESCRIPTION
Spec fixed upstream (and event was renamed)