### PR TITLE
Add links to Gost-DOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ The following projects are known to use webref data:
 * [nodysseus](https://gitlab.com/ulysses.codes/nodysseus)
 * [WebIDLPedia](https://dontcallmedom.github.io/webidlpedia/)
 * [Webdex](https://dontcallmedom.github.io/webdex/)
+* [Gost-DOM](https://github.com/gost-dom/browser), a headless browser for Go (early prototype available).
+* [Gost-DOM Webref](https://github.com/gost-dom/webref) exposing parts of the data as native Go objects.
 
 Using webref data in a project that is not yet in the list? Let us know!
 


### PR DESCRIPTION
I created a headless browser in Go, and use the webref to generate primarily JavaScript bindings to Go objects, as well as mapping element tagnames to IDL interface name.

The actual parsing of webref files were extracted as its own library.

It's very early prototype supporting only a very small subset of the standard, but it does support a session-based username/password login flow using HTMX.

So if it's enough to be in the list must be for you to judge :)
