### PR TITLE
Refresh and expand patch for ed/idl/web-animations-2.idl

### DIFF
--- a/ed/idlpatches/web-animations-2.idl.patch
+++ b/ed/idlpatches/web-animations-2.idl.patch
@@ -1,6 +1,6 @@
-From 229ec4c150f1c7fa2b204ab565b476efd1d24e25 Mon Sep 17 00:00:00 2001
+From 9afc09a9b0b3c11be7ae1bebe5d3d8400abd58ec Mon Sep 17 00:00:00 2001
 From: Francois Daoust <fd@tidoust.net>
-Date: Thu, 29 Feb 2024 22:16:05 +0100
+Date: Tue, 4 Feb 2025 13:44:24 +0100
 Subject: [PATCH] Drop duplicate `fillMode` enum, rollback range changes
 
 The spec is a delta spec and re-defines the `fillMode` enum to change the
@@ -11,24 +11,25 @@ delta spec.
 
 The `rangeStart` and `rangeEnd` definitions are currently invalid, pending:
 https://github.com/w3c/csswg-drafts/pull/9360
+https://github.com/w3c/csswg-drafts/issues/11624
 ---
- ed/idl/web-animations-2.idl | 4 ----
- 1 file changed, 4 deletions(-)
+ ed/idl/web-animations-2.idl | 12 ------------
+ 1 file changed, 12 deletions(-)
 
 diff --git a/ed/idl/web-animations-2.idl b/ed/idl/web-animations-2.idl
-index 4dc3980d5..4c3af5351 100644
+index 6bd3067d5..ad047f573 100644
 --- a/ed/idl/web-animations-2.idl
 +++ b/ed/idl/web-animations-2.idl
-@@ -14,8 +14,6 @@ partial interface AnimationTimeline {
- partial interface Animation {
+@@ -15,8 +15,6 @@ partial interface Animation {
      attribute CSSNumberish?       startTime;
      attribute CSSNumberish?       currentTime;
+     attribute AnimationTrigger?   trigger;
 -    attribute (TimelineRangeOffset or CSSNumericValue or CSSKeywordValue or DOMString) rangeStart;
 -    attribute (TimelineRangeOffset or CSSNumericValue or CSSKeywordValue or DOMString) rangeEnd;
      readonly attribute double? overallProgress;
  };
  
-@@ -50,8 +48,6 @@ partial dictionary ComputedEffectTiming {
+@@ -51,8 +49,6 @@ partial dictionary ComputedEffectTiming {
      CSSNumberish?        localTime;
  };
  
@@ -37,6 +38,26 @@ index 4dc3980d5..4c3af5351 100644
  [Exposed=Window]
  interface GroupEffect {
    constructor(sequence<AnimationEffect>? children,
+@@ -123,19 +119,11 @@ interface AnimationTrigger {
+   constructor(optional AnimationTriggerOptions options = {});
+   attribute AnimationTimeline timeline;
+   attribute AnimationTriggerType type;
+-  attribute (TimelineRangeOffset or CSSNumericValue or CSSKeywordValue or DOMString) rangeStart = "normal";
+-  attribute (TimelineRangeOffset or CSSNumericValue or CSSKeywordValue or DOMString) rangeEnd = "normal";
+-  attribute (TimelineRangeOffset or CSSNumericValue or CSSKeywordValue or DOMString) exitRangeStart = "auto";
+-  attribute (TimelineRangeOffset or CSSNumericValue or CSSKeywordValue or DOMString) exitRangeEnd = "auto";
+ };
+ 
+ dictionary AnimationTriggerOptions {
+   AnimationTimeline? timeline;
+   AnimationTriggerType? type = "once";
+-  (TimelineRangeOffset or CSSNumericValue or CSSKeywordValue or DOMString)? rangeStart = "normal";
+-  (TimelineRangeOffset or CSSNumericValue or CSSKeywordValue or DOMString)? rangeEnd = "normal";
+-  (TimelineRangeOffset or CSSNumericValue or CSSKeywordValue or DOMString)? exitRangeStart = "auto";
+-  (TimelineRangeOffset or CSSNumericValue or CSSKeywordValue or DOMString)? exitRangeEnd = "auto";
+ };
+ 
+ enum AnimationTriggerType { "once", "repeat", "alternate", "state" };
 -- 
 2.37.1.windows.1
 


### PR DESCRIPTION
New IDL changes in the spec introduced additional errors similar to the ones that we previously patched.