### PR TITLE
Drop dependency on flags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "@webref/events": "file:packages/events",
         "@webref/idl": "file:packages/idl",
         "css-tree": "3.1.0",
-        "flags": "0.2.2",
         "mocha": "11.1.0",
         "reffy": "18.4.0",
         "rimraf": "6.0.1",
@@ -1385,12 +1384,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/flags": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/flags/-/flags-0.2.2.tgz",
-      "integrity": "sha512-io/l8F1LPmOWGWmgJSzRDhMwBhRpw0m/ZATweM8iV1yvpbM5kkMlYM4wnuHSDfJ5NUDMeSyLbF0FtoNWR0f+WQ==",
-      "dev": true
     },
     "node_modules/flat": {
       "version": "5.0.2",
@@ -4464,12 +4457,6 @@
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
       }
-    },
-    "flags": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/flags/-/flags-0.2.2.tgz",
-      "integrity": "sha512-io/l8F1LPmOWGWmgJSzRDhMwBhRpw0m/ZATweM8iV1yvpbM5kkMlYM4wnuHSDfJ5NUDMeSyLbF0FtoNWR0f+WQ==",
-      "dev": true
     },
     "flat": {
       "version": "5.0.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@webref/events": "file:packages/events",
     "@webref/idl": "file:packages/idl",
     "css-tree": "3.1.0",
-    "flags": "0.2.2",
     "mocha": "11.1.0",
     "reffy": "18.4.0",
     "rimraf": "6.0.1",


### PR DESCRIPTION
The dependency comes from ancient times when the repository contained the code used to synchronize with WPT. That code was moved to the WPT repository a long time ago already. Remaining code in Webref does not use flags.

Prompted by #1475.