### PR TITLE
Drop event patch for Service Workers

### DIFF
--- a/tools/amend-event-data.js
+++ b/tools/amend-event-data.js
@@ -365,19 +365,6 @@ const patches = {
       change: { interface: "Event", bubbles: false }
     }
   ],
-  'service-workers': [
-    {
-      pattern: { href: "https://wicg.github.io/BackgroundSync/spec/#sync" },
-      matched: 1,
-      change: { href: "https://wicg.github.io/background-sync/spec/#sync"}
-    },
-    // pending https://github.com/w3c/ServiceWorker/pull/1706
-    {
-      pattern: { type: "install" },
-      matched: 1,
-      change: { interface: "InstallEvent" }
-    }
-  ],
   'speech-api': [
     {
       pattern: {


### PR DESCRIPTION
The `install` event interface was fixed some time ago. The URL of the `sync` event has now been updated.

(That won't be enough to fix data curation, SVG Filter Effects' hiccup still exists)