### PR TITLE
Add "freeze patch" mechanism, add one for filter-effects-1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        # Need to checkout all history for curation job
+        fetch-depth: 0
     - uses: actions/setup-node@v4
       with:
         node-version: 20

--- a/ed/freezepatches/README.md
+++ b/ed/freezepatches/README.md
@@ -1,0 +1,8 @@
+# Freeze patches
+
+These are patches applied to specs to freeze all the extracts for that spec to a past result, identified by a commit ID.
+
+Each patch should be a JSON file named after the spec's shortname that defines a JSON object with two keys:
+
+- `commit`: The full commit ID in Webref that identifies the crawl results to use for the spec.
+- `pending`: The URL of an issue that tracks the problem. This allows to detect when the patch is no longer needed.

--- a/ed/freezepatches/filter-effects-1.json
+++ b/ed/freezepatches/filter-effects-1.json
@@ -1,4 +1,4 @@
 {
-  "commit": "40defbb2afaad2bc98fca473f7dbea844eb4020e",
+  "commit": "647faa1643647b66b31a505e5b247a8695955352",
   "pending": "https://github.com/w3c/fxtf-drafts/issues/591"
 }

--- a/ed/freezepatches/filter-effects-1.json
+++ b/ed/freezepatches/filter-effects-1.json
@@ -1,0 +1,4 @@
+{
+  "commit": "40defbb2afaad2bc98fca473f7dbea844eb4020e",
+  "pending": "https://github.com/w3c/fxtf-drafts/issues/591"
+}

--- a/tools/apply-patches.js
+++ b/tools/apply-patches.js
@@ -19,7 +19,7 @@ import path from 'node:path';
 import util from 'node:util';
 import { fileURLToPath } from 'node:url';
 import { execFile as execCb } from 'node:child_process';
-import { createFolderIfNeeded } from './utils.js';
+import { createFolderIfNeeded, loadJSON } from './utils.js';
 const execFile = util.promisify(execCb);
 
 async function applyPatches(rawFolder, outputFolder, type) {
@@ -61,6 +61,7 @@ async function applyPatches(rawFolder, outputFolder, type) {
   ];
 
   await createFolderIfNeeded(outputFolder);
+  await applyFreezePatches(rawFolder, outputFolder);
 
   for (const { name, srcDir, dstDir, patchDir, fileExt } of packages) {
     if (!type.includes(name)) {
@@ -96,6 +97,82 @@ async function applyPatches(rawFolder, outputFolder, type) {
         await execFile('git', ['apply', `--directory=${outputFolder}/${name}`, '-p3', patch]);
       }
     }
+  }
+}
+
+
+/**
+ * Apply "freeze" patches, which freeze curation data for a spec to the results
+ * of a previous crawl result, identified by a commit ID.
+ *
+ * Freeze patches are meant to be used for specs that are (hopefully
+ * temporarily) severely broken.
+ */
+async function applyFreezePatches(rawFolder, outputFolder) {
+  const patchDir = path.join(rawFolder, 'freezepatches');
+  const patchFiles = await fs.readdir(patchDir);
+
+  const outputIndex = await loadJSON(path.join(outputFolder, 'index.json'));
+  let patchApplied = false;
+
+  for (const file of patchFiles) {
+    if (!file.endsWith('.json')) {
+      continue;
+    }
+
+    const shortname = file.replace(/\.json$/, '');
+    const branchName = `freezepatch-${shortname}`;
+    const patch = path.join(patchDir, file);
+    const json = await loadJSON(patch);
+
+    console.log(`Applying ${path.relative(rawFolder, patch)}`);
+    const outputSpecPos = outputIndex.results.findIndex(spec => spec.shortname === shortname);
+
+    // Get back to the patch commit
+    // (note this does not touch the `curated` folder because it is in
+    // the `.gitignore` file)
+    await execFile('git', ['checkout', '-B', branchName, json.commit]);
+
+    const crawlIndex = await loadJSON(path.join(rawFolder, 'index.json'));
+    const crawlSpec = crawlIndex.results.find(spec => spec.shortname === shortname);
+
+    for (const [extractType, extractFile] of Object.entries(crawlSpec)) {
+      if (extractType === 'cddl') {
+        // Handle CDDL extracts separately, it's an array of extracts
+        for (const { file: cddlFile } of extractFile) {
+          await fs.copyFile(
+            path.join(rawFolder, cddlFile),
+            path.join(outputFolder, cddlFile)
+          );
+        }
+      }
+      else if (!extractFile ||
+          (typeof extractFile !== 'string') ||
+          !extractFile.match(/^[^\/]+\/[^\/]+\.(json|idl)$/)) {
+        // Skip properties that do not link to an extract
+        continue;
+      }
+      else {
+        await fs.copyFile(
+          path.join(rawFolder, extractFile),
+          path.join(outputFolder, extractFile)
+        );
+      }
+      outputIndex.results.splice(outputSpecPos, 1, crawlSpec);
+    }
+
+    await execFile('git', ['checkout', 'main']);
+    await execFile('git', ['branch', '-D', branchName]);
+    patchApplied = true;
+  }
+
+  // Update curated version of the index.json file
+  if (patchApplied) {
+    await fs.writeFile(
+      path.join(outputFolder, 'index.json'),
+      JSON.stringify(outputIndex, null, 2),
+      'utf8'
+    );
   }
 }
 

--- a/tools/apply-patches.js
+++ b/tools/apply-patches.js
@@ -137,7 +137,7 @@ async function applyFreezePatches(rawFolder, outputFolder) {
 
     for (const propValue of Object.values(crawlSpec)) {
       const extractFiles = getTargetedExtracts(propValue);
-      for (const extractFile of extracFiles) {
+      for (const extractFile of extractFiles) {
         await fs.copyFile(
           path.join(rawFolder, extractFile),
           path.join(outputFolder, extractFile)

--- a/tools/utils.js
+++ b/tools/utils.js
@@ -68,8 +68,30 @@ async function copyFolder(source, target, { excludeRoot = false } = {}) {
 };
 
 
+/**
+ * Return the list of extract files that the given value targets.
+ *
+ * Note: The `cddl` property value targets an array of extracts, the actual
+ * extract being under the `file` key each time.
+ */
+function getTargetedExtracts(value) {
+  const reExtractFile = /^[^\/]+\/[^\/]+\.(json|idl|cddl)$/;
+  if (Array.isArray(value)) {
+    return value
+      .filter(v => typeof v.file === 'string' && v.file.match(reExtractFile))
+      .map(v => v.file);
+  }
+  else if (typeof value === 'string') {
+    return [value];
+  }
+  else {
+    return [];
+  }
+}
+
 export {
   createFolderIfNeeded,
   loadJSON,
-  copyFolder
+  copyFolder,
+  getTargetedExtracts
 };

--- a/tools/utils.js
+++ b/tools/utils.js
@@ -81,7 +81,7 @@ function getTargetedExtracts(value) {
       .filter(v => typeof v.file === 'string' && v.file.match(reExtractFile))
       .map(v => v.file);
   }
-  else if (typeof value === 'string') {
+  else if (typeof value === 'string' && value.match(reExtractFile)) {
     return [value];
   }
   else {


### PR DESCRIPTION
This creates a new way to curate the results of a crawl: a freeze patch allows to freeze the results of a crawl to a specific commit ID in Webref. This is meant for specs that are temporarily broken beyond repair.

First such patch is for the filter-effects-1 spec.

Each freeze patch is implemented as a JSON file named after the spec's shortname and that contains the commit ID and a `pending` key that links to the issue that tracks the problem in some GitHub repository. The `clean-patches` script proposes to drop the patch when the issue gets closed.