### PR TITLE
Adjust patch for saa-non-cookie-storage

### DIFF
--- a/ed/idlpatches/saa-non-cookie-storage.idl.patch
+++ b/ed/idlpatches/saa-non-cookie-storage.idl.patch
@@ -16,7 +16,7 @@ index 45330025c..6cc0a7887 100644
  
  partial interface Document {
    Promise<boolean> hasUnpartitionedCookieAccess();
--  Promise<StorageAccessHandle> requestStorageAccess(StorageAccessTypes types);
+-  Promise<StorageAccessHandle> requestStorageAccess(optional StorageAccessTypes types = {});
  };
  
  enum SameSiteCookiesType { "all", "none" };


### PR DESCRIPTION
Spec now defines the `requestStorageAccess` parameter as optional, and notes in an inline issue that this won't work unless Web IDL adopts a mechanism to specify that a dictionary cannot be empty. In the meantime, the problem is the same as before from a curation perspective.