### PR TITLE
Runs the CSS consolidation logic during curation

### DIFF
--- a/tools/prepare-curated.js
+++ b/tools/prepare-curated.js
@@ -4,7 +4,7 @@
  * Curation means copying raw data to the given folder, applying patches (CSS,
  * elements, events, IDL) when needed and running post-processing modules that
  * need to run on curated data to generate the `idlparsed`, `idlnames` and
- * `idlnamesparsed` folders, and the merged `events.json` file
+ * `idlnamesparsed` folders, and the merged `events.json` and `css.json` files.
  *
  * The output folder gets created if it does not exist yet. Output folder
  * contents get deleted to start with if folder is not empty.
@@ -125,7 +125,7 @@ async function prepareCurated(rawFolder, curatedFolder) {
   await crawlSpecs({
     useCrawl: curatedFolder,
     output: curatedFolder,
-    post: ['idlparsed', 'idlnames', 'events'],
+    post: ['idlparsed', 'idlnames', 'events', 'cssmerge'],
     quiet: true
   });
   console.log('- done');


### PR DESCRIPTION
This calls the new `cssmerge` post-processing module of Reffy during data curation to generate the consolidated `css.json` file.

Note: A few tests should be written to check the consolidated file before it gets released in any package (and mentioned in the docs). Plan is to do that separately.