### PR TITLE
Add a few tests on consolidated CSS file

### DIFF
--- a/test/css/consolidated.js
+++ b/test/css/consolidated.js
@@ -1,0 +1,46 @@
+/**
+ * Test the consolidated css.json file in the curated view.
+ */
+
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import consolidated from '../../curated/css.json' with { type: 'json' };
+import { definitionSyntax } from 'css-tree';
+
+// Expected categories in the consolidated file
+const categories = {
+  atrules: { singular: 'at-rule', plural: 'at-rules' },
+  functions: { singular: 'function', plural: 'functions' },
+  properties: { singular: 'property', plural: 'properties' },
+  selectors: { singular: 'selector', plural: 'selectors' },
+  types: { singular: 'type', plural: 'types' }
+};
+
+describe(`The consolidated CSS file`, async () => {
+  for (const [category, { singular, plural }] of Object.entries(categories)) {
+    const list = consolidated[category];
+
+    it(`contains ${plural}`, () => {
+      assert(list);
+      assert(list.length > 0);
+    });
+
+    it(`does not contain duplicated ${plural}`, () => {
+      const keys = list.map(entry => entry.name +
+        (entry.for ? ` for ${entry.for}` : ''));
+      const duplicates = keys.filter((key, idx) =>
+        keys.findIndex(k => k === key) !== idx);
+      assert.deepEqual(duplicates, []);
+    });
+
+    it(`contains valid ${singular} syntaxes`, () => {
+      const invalid = list
+        .filter(entry => entry.value)
+        .filter(entry => {
+          const ast = definitionSyntax.parse(entry.value);
+          return !ast.type;
+        });
+      assert.deepEqual(invalid, []);
+    });
+  }
+});

--- a/test/css/consolidated.js
+++ b/test/css/consolidated.js
@@ -9,23 +9,33 @@ import { definitionSyntax } from 'css-tree';
 
 // Expected categories in the consolidated file
 const categories = {
-  atrules: { singular: 'at-rule', plural: 'at-rules' },
-  functions: { singular: 'function', plural: 'functions' },
-  properties: { singular: 'property', plural: 'properties' },
-  selectors: { singular: 'selector', plural: 'selectors' },
-  types: { singular: 'type', plural: 'types' }
+  atrules: 'at-rule',
+  functions: 'function',
+  properties: 'property',
+  selectors: 'selector',
+  types: 'type'
 };
 
+// Quick and dirty function to pluralize category labels
+function pluralize(word) {
+  if (word === 'property') {
+    return 'properties';
+  }
+  else {
+    return word + 's';
+  }
+}
+
 describe(`The consolidated CSS file`, async () => {
-  for (const [category, { singular, plural }] of Object.entries(categories)) {
+  for (const [category, label] of Object.entries(categories)) {
     const list = consolidated[category];
 
-    it(`contains ${plural}`, () => {
+    it(`contains ${pluralize(label)}`, () => {
       assert(list);
       assert(list.length > 0);
     });
 
-    it(`does not contain duplicated ${plural}`, () => {
+    it(`does not contain duplicated ${pluralize(label)}`, () => {
       const keys = list.map(entry => entry.name +
         (entry.for ? ` for ${entry.for}` : ''));
       const duplicates = keys.filter((key, idx) =>
@@ -33,7 +43,7 @@ describe(`The consolidated CSS file`, async () => {
       assert.deepEqual(duplicates, []);
     });
 
-    it(`contains valid ${singular} syntaxes`, () => {
+    it(`contains valid ${label} syntaxes`, () => {
       const invalid = list
         .filter(entry => entry.value)
         .filter(entry => {


### PR DESCRIPTION
This adds tests to guarantee that entries are unique in the consolidated CSS file (they should be by construction, tests are meant to capture bugs that we might miss if we update the consolidation logic in Reffy).

Consolidation amends syntaxes of some of the entries. Tests also make sure that syntaxes can be parsed with CSSTree.