### PR TITLE
IDL patches for `ReportBody`

### DIFF
--- a/ed/idlpatches/CSP.idl.patch
+++ b/ed/idlpatches/CSP.idl.patch
@@ -1,0 +1,51 @@
+From 85479132134d3bdedda543910b0559ffa895c4af Mon Sep 17 00:00:00 2001
+From: Francois Daoust <fd@tidoust.net>
+Date: Mon, 16 Jun 2025 12:09:32 +0200
+Subject: [PATCH] Turn interface into dictionary
+
+Pending complete resolution of:
+https://github.com/w3c/reporting/issues/216
+---
+ ed/idl/CSP.idl | 26 ++++++++++++--------------
+ 1 file changed, 12 insertions(+), 14 deletions(-)
+
+diff --git a/ed/idl/CSP.idl b/ed/idl/CSP.idl
+index d4a6377ebb..cee3015c7e 100644
+--- a/ed/idl/CSP.idl
++++ b/ed/idl/CSP.idl
+@@ -3,20 +3,18 @@
+ // (https://github.com/w3c/webref)
+ // Source: Content Security Policy Level 3 (https://w3c.github.io/webappsec-csp/)
+ 
+-[Exposed=Window]
+-interface CSPViolationReportBody : ReportBody {
+-  [Default] object toJSON();
+-  readonly attribute USVString documentURL;
+-  readonly attribute USVString? referrer;
+-  readonly attribute USVString? blockedURL;
+-  readonly attribute DOMString effectiveDirective;
+-  readonly attribute DOMString originalPolicy;
+-  readonly attribute USVString? sourceFile;
+-  readonly attribute DOMString? sample;
+-  readonly attribute SecurityPolicyViolationEventDisposition disposition;
+-  readonly attribute unsigned short statusCode;
+-  readonly attribute unsigned long? lineNumber;
+-  readonly attribute unsigned long? columnNumber;
++dictionary CSPViolationReportBody : ReportBody {
++  USVString documentURL;
++  USVString? referrer;
++  USVString? blockedURL;
++  DOMString effectiveDirective;
++  DOMString originalPolicy;
++  USVString? sourceFile;
++  DOMString? sample;
++  SecurityPolicyViolationEventDisposition disposition;
++  unsigned short statusCode;
++  unsigned long? lineNumber;
++  unsigned long? columnNumber;
+ };
+ 
+ enum SecurityPolicyViolationEventDisposition {
+-- 
+2.37.1.windows.1
+

--- a/ed/idlpatches/crash-reporting.idl.patch
+++ b/ed/idlpatches/crash-reporting.idl.patch
@@ -1,0 +1,35 @@
+From db6d1eb54b5bc6ebf5096fbcdb75feaa3158649b Mon Sep 17 00:00:00 2001
+From: Francois Daoust <fd@tidoust.net>
+Date: Mon, 16 Jun 2025 12:07:43 +0200
+Subject: [PATCH] Turn interface into dictionary
+
+Pending complete resolution of:
+https://github.com/w3c/reporting/issues/216
+---
+ ed/idl/crash-reporting.idl | 12 +++++-------
+ 1 file changed, 5 insertions(+), 7 deletions(-)
+
+diff --git a/ed/idl/crash-reporting.idl b/ed/idl/crash-reporting.idl
+index ba21afcf39..d10f357379 100644
+--- a/ed/idl/crash-reporting.idl
++++ b/ed/idl/crash-reporting.idl
+@@ -3,11 +3,9 @@
+ // (https://github.com/w3c/webref)
+ // Source: Crash Reporting (https://wicg.github.io/crash-reporting/)
+ 
+-[Exposed=(Window,Worker)]
+-interface CrashReportBody : ReportBody {
+-  [Default] object toJSON();
+-  readonly attribute DOMString? reason;
+-  readonly attribute DOMString? stack;
+-  readonly attribute boolean? is_top_level;
+-  readonly attribute DocumentVisibilityState? page_visibility;
++dictionary CrashReportBody : ReportBody {
++  DOMString? reason;
++  DOMString? stack;
++  boolean? is_top_level;
++  DocumentVisibilityState? page_visibility;
+ };
+-- 
+2.37.1.windows.1
+

--- a/ed/idlpatches/csp-next.idl.patch
+++ b/ed/idlpatches/csp-next.idl.patch
@@ -1,0 +1,37 @@
+From cea604220649684e3a39a34687544304cecc4fcf Mon Sep 17 00:00:00 2001
+From: Francois Daoust <fd@tidoust.net>
+Date: Mon, 16 Jun 2025 12:08:49 +0200
+Subject: [PATCH] Turn interface into dictionary
+
+Pending complete resolution of:
+https://github.com/w3c/reporting/issues/216
+---
+ ed/idl/csp-next.idl | 14 ++++++--------
+ 1 file changed, 6 insertions(+), 8 deletions(-)
+
+diff --git a/ed/idl/csp-next.idl b/ed/idl/csp-next.idl
+index d94b36cf88..f17c4b3a5f 100644
+--- a/ed/idl/csp-next.idl
++++ b/ed/idl/csp-next.idl
+@@ -10,12 +10,10 @@ enum ScriptingPolicyViolationType {
+   "eval"
+ };
+ 
+-[Exposed=(Window,Worker), SecureContext]
+-interface ScriptingPolicyReportBody : ReportBody {
+-  [Default] object toJSON();
+-  readonly attribute DOMString     violationType;
+-  readonly attribute USVString?    violationURL;
+-  readonly attribute USVString?    violationSample;
+-  readonly attribute unsigned long lineno;
+-  readonly attribute unsigned long colno;
++dictionary ScriptingPolicyReportBody : ReportBody {
++  DOMString     violationType;
++  USVString?    violationURL;
++  USVString?    violationSample;
++  unsigned long lineno;
++  unsigned long colno;
+ };
+-- 
+2.37.1.windows.1
+

--- a/ed/idlpatches/deprecation-reporting.idl.patch
+++ b/ed/idlpatches/deprecation-reporting.idl.patch
@@ -1,0 +1,39 @@
+From cb1c6ea2a6b172c3eb6df15a92a2c39ffb103f16 Mon Sep 17 00:00:00 2001
+From: Francois Daoust <fd@tidoust.net>
+Date: Mon, 16 Jun 2025 12:10:09 +0200
+Subject: [PATCH] Turn interface into dictionary
+
+Pending complete resolution of:
+https://github.com/w3c/reporting/issues/216
+---
+ ed/idl/deprecation-reporting.idl | 16 +++++++---------
+ 1 file changed, 7 insertions(+), 9 deletions(-)
+
+diff --git a/ed/idl/deprecation-reporting.idl b/ed/idl/deprecation-reporting.idl
+index 4cf76ba811..8f6e963918 100644
+--- a/ed/idl/deprecation-reporting.idl
++++ b/ed/idl/deprecation-reporting.idl
+@@ -3,13 +3,11 @@
+ // (https://github.com/w3c/webref)
+ // Source: Deprecation Reporting (https://wicg.github.io/deprecation-reporting/)
+ 
+-[Exposed=(Window,Worker)]
+-interface DeprecationReportBody : ReportBody {
+-  [Default] object toJSON();
+-  readonly attribute DOMString id;
+-  readonly attribute object? anticipatedRemoval;
+-  readonly attribute DOMString message;
+-  readonly attribute DOMString? sourceFile;
+-  readonly attribute unsigned long? lineNumber;
+-  readonly attribute unsigned long? columnNumber;
++dictionary DeprecationReportBody : ReportBody {
++  DOMString id;
++  object? anticipatedRemoval;
++  DOMString message;
++  DOMString? sourceFile;
++  unsigned long? lineNumber;
++  unsigned long? columnNumber;
+ };
+-- 
+2.37.1.windows.1
+

--- a/ed/idlpatches/intervention-reporting.idl.patch
+++ b/ed/idlpatches/intervention-reporting.idl.patch
@@ -1,0 +1,37 @@
+From 7b1e4bfdc8e0bb7390e6ba1f0a16eb2c5bb0f422 Mon Sep 17 00:00:00 2001
+From: Francois Daoust <fd@tidoust.net>
+Date: Mon, 16 Jun 2025 12:10:46 +0200
+Subject: [PATCH] Turn interface into dictionary
+
+Pending complete resolution of:
+https://github.com/w3c/reporting/issues/216
+---
+ ed/idl/intervention-reporting.idl | 14 ++++++--------
+ 1 file changed, 6 insertions(+), 8 deletions(-)
+
+diff --git a/ed/idl/intervention-reporting.idl b/ed/idl/intervention-reporting.idl
+index 3c3b8001e7..e1fabd8bf2 100644
+--- a/ed/idl/intervention-reporting.idl
++++ b/ed/idl/intervention-reporting.idl
+@@ -3,12 +3,10 @@
+ // (https://github.com/w3c/webref)
+ // Source: Intervention Reporting (https://wicg.github.io/intervention-reporting/)
+ 
+-[Exposed=(Window,Worker)]
+-interface InterventionReportBody : ReportBody {
+-  [Default] object toJSON();
+-  readonly attribute DOMString id;
+-  readonly attribute DOMString message;
+-  readonly attribute DOMString? sourceFile;
+-  readonly attribute unsigned long? lineNumber;
+-  readonly attribute unsigned long? columnNumber;
++dictionary InterventionReportBody : ReportBody {
++  DOMString id;
++  DOMString message;
++  DOMString? sourceFile;
++  unsigned long? lineNumber;
++  unsigned long? columnNumber;
+ };
+-- 
+2.37.1.windows.1
+

--- a/ed/idlpatches/permissions-policy.idl.patch
+++ b/ed/idlpatches/permissions-policy.idl.patch
@@ -1,0 +1,41 @@
+From 4e1302e1192564ceeaf443e0b044ca9f559afeb0 Mon Sep 17 00:00:00 2001
+From: Francois Daoust <fd@tidoust.net>
+Date: Mon, 16 Jun 2025 12:11:25 +0200
+Subject: [PATCH] Turn interface into dictionary
+
+Pending complete resolution of:
+https://github.com/w3c/reporting/issues/216
+---
+ ed/idl/permissions-policy.idl | 18 ++++++++----------
+ 1 file changed, 8 insertions(+), 10 deletions(-)
+
+diff --git a/ed/idl/permissions-policy.idl b/ed/idl/permissions-policy.idl
+index b17304de8d..46eb6914a3 100644
+--- a/ed/idl/permissions-policy.idl
++++ b/ed/idl/permissions-policy.idl
+@@ -19,14 +19,12 @@ partial interface HTMLIFrameElement {
+     [SameObject] readonly attribute PermissionsPolicy permissionsPolicy;
+ };
+ 
+-[Exposed=Window]
+-interface PermissionsPolicyViolationReportBody : ReportBody {
+-  [Default] object toJSON();
+-  readonly attribute DOMString featureId;
+-  readonly attribute DOMString? sourceFile;
+-  readonly attribute long? lineNumber;
+-  readonly attribute long? columnNumber;
+-  readonly attribute DOMString disposition;
+-  readonly attribute DOMString? allowAttribute;
+-  readonly attribute DOMString? srcAttribute;
++dictionary PermissionsPolicyViolationReportBody : ReportBody {
++  DOMString featureId;
++  DOMString? sourceFile;
++  long? lineNumber;
++  long? columnNumber;
++  DOMString disposition;
++  DOMString? allowAttribute;
++  DOMString? srcAttribute;
+ };
+-- 
+2.37.1.windows.1
+


### PR DESCRIPTION
Similar patch applied to 6 specs following conversion of `ReportBody` from an interface to a dictionary.