### PR TITLE
Add patch for ed/css/css-values-5.json

### DIFF
--- a/ed/csspatches/css-values-5.json.patch
+++ b/ed/csspatches/css-values-5.json.patch
@@ -1,0 +1,61 @@
+From 9140482c4286396f349b4d8ee4a3b7a58b7d74d6 Mon Sep 17 00:00:00 2001
+From: Francois Daoust <fd@tidoust.net>
+Date: Fri, 20 Jun 2025 12:27:26 +0200
+Subject: [PATCH] Fix dfn of `<input-position>`
+
+Pending https://github.com/w3c/csswg-drafts/pull/12349
+---
+ ed/css/css-values-5.json | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/ed/css/css-values-5.json b/ed/css/css-values-5.json
+index 2ac8fe8161..cb5e24ea50 100644
+--- a/ed/css/css-values-5.json
++++ b/ed/css/css-values-5.json
+@@ -401,8 +401,8 @@
+           "value": "by"
+         },
+         {
+-          "name": "<input-position>{1,2} : <output-value>",
+-          "value": "<input-position>",
++          "name": "<input-position>",
++          "value": "<percentage> | <number> | <dimension>",
+           "href": "https://drafts.csswg.org/css-values-5/#typedef-calc-interpolate-input-position",
+           "type": "type"
+         },
+@@ -436,8 +436,8 @@
+           "value": "by"
+         },
+         {
+-          "name": "<input-position>{1,2} : <output-value>",
+-          "value": "<input-position>",
++          "name": "<input-position>",
++          "value": "<percentage> | <number> | <dimension>",
+           "href": "https://drafts.csswg.org/css-values-5/#typedef-calc-interpolate-input-position",
+           "type": "type"
+         },
+@@ -471,8 +471,8 @@
+           "value": "by"
+         },
+         {
+-          "name": "<input-position>{1,2} : <output-value>",
+-          "value": "<input-position>",
++          "name": "<input-position>",
++          "value": "<percentage> | <number> | <dimension>",
+           "href": "https://drafts.csswg.org/css-values-5/#typedef-calc-interpolate-input-position",
+           "type": "type"
+         },
+@@ -506,8 +506,8 @@
+           "value": "by"
+         },
+         {
+-          "name": "<input-position>{1,2} : <output-value>",
+-          "value": "<input-position>",
++          "name": "<input-position>",
++          "value": "<percentage> | <number> | <dimension>",
+           "href": "https://drafts.csswg.org/css-values-5/#typedef-calc-interpolate-input-position",
+           "type": "type"
+         },
+-- 
+2.37.1.windows.1
+


### PR DESCRIPTION
Fix dfn of `<input-position>`. I haven't tried to create an entry for `<output-value>` (not a very interesting type in any case as it does not come with an explicit syntax).