### PR TITLE
Add patch for ed/css/selectors-5.json

### DIFF
--- a/ed/csspatches/selectors-5.json.patch
+++ b/ed/csspatches/selectors-5.json.patch
@@ -1,0 +1,27 @@
+From 6be6632617b659b9214836695652656862afdd8a Mon Sep 17 00:00:00 2001
+From: Francois Daoust <fd@tidoust.net>
+Date: Mon, 30 Jun 2025 09:22:21 +0200
+Subject: [PATCH] Fix syntax of ref to `An+B` type
+
+Pending adoption of a final valid name for `An+B` in css-syntax-3:
+https://github.com/w3c/csswg-drafts/issues/9473
+---
+ ed/css/selectors-5.json | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ed/css/selectors-5.json b/ed/css/selectors-5.json
+index 065ad05c95..a51dbd849b 100644
+--- a/ed/css/selectors-5.json
++++ b/ed/css/selectors-5.json
+@@ -27,7 +27,7 @@
+       "name": ":heading()",
+       "prose": "As a functional pseudo-class, :heading() notation represents elements that have a heading level among An+B. The syntax is:",
+       "href": "https://drafts.csswg.org/selectors-5/#heading-functional-pseudo",
+-      "value": ":heading( <An+B># )"
++      "value": ":heading( <An-B># )"
+     }
+   ],
+   "values": []
+-- 
+2.37.1.windows.1
+


### PR DESCRIPTION
Fix syntax of ref to `An+B` type.

I'll probably go ahead and patch the definition in `css-syntax-3` so that the `An-B` type actually exists.