### PR TITLE
Re-create IDL patch for SVG

### DIFF
--- a/ed/idlpatches/SVG.idl.patch
+++ b/ed/idlpatches/SVG.idl.patch
@@ -1,6 +1,6 @@
-From faaa4cf0e963176563339e6befb3fb84077d5f7f Mon Sep 17 00:00:00 2001
+From 33100cd5a88ed25de6c28ec392943ae0b6e674a6 Mon Sep 17 00:00:00 2001
 From: Francois Daoust <fd@tidoust.net>
-Date: Thu, 6 Mar 2025 16:31:29 +0100
+Date: Mon, 15 Sep 2025 08:08:58 +0200
 Subject: [PATCH] Fix IDL of SVG spec
 
 HTMLHyperlinkElementUtils: https://github.com/w3c/svgwg/issues/312
@@ -8,22 +8,14 @@ HTMLHyperlinkElementUtils: https://github.com/w3c/svgwg/issues/312
 Also drop `SVGPathElement`, now that SVG Paths is also being crawled, pending
 clarification of status between SVG 2 and SVG Paths.
 ---
- ed/idl/SVG.idl | 20 ++++++++++++++------
- 1 file changed, 14 insertions(+), 6 deletions(-)
+ ed/idl/SVG.idl | 19 ++++++++++++++-----
+ 1 file changed, 14 insertions(+), 5 deletions(-)
 
 diff --git a/ed/idl/SVG.idl b/ed/idl/SVG.idl
-index 9ce619d1e..5dff2947b 100644
+index d046678667..6f6409daea 100644
 --- a/ed/idl/SVG.idl
 +++ b/ed/idl/SVG.idl
-@@ -13,7 +13,6 @@ interface SVGElement : Element {
- };
- 
- SVGElement includes GlobalEventHandlers;
--SVGElement includes DocumentAndElementEventHandlers;
- SVGElement includes SVGElementInstance;
- SVGElement includes HTMLOrSVGElement;
- 
-@@ -419,10 +418,6 @@ interface SVGAnimatedPreserveAspectRatio {
+@@ -418,10 +418,6 @@ interface SVGAnimatedPreserveAspectRatio {
    [SameObject] readonly attribute SVGPreserveAspectRatio animVal;
  };
  
@@ -34,7 +26,7 @@ index 9ce619d1e..5dff2947b 100644
  [Exposed=Window]
  interface SVGRectElement : SVGGeometryElement {
    [SameObject] readonly attribute SVGAnimatedLength x;
-@@ -673,7 +668,20 @@ interface SVGAElement : SVGGraphicsElement {
+@@ -671,7 +667,20 @@ interface SVGAElement : SVGGraphicsElement {
  };
  
  SVGAElement includes SVGURIReference;
@@ -57,5 +49,5 @@ index 9ce619d1e..5dff2947b 100644
  [Exposed=Window]
  interface SVGViewElement : SVGElement {};
 -- 
-2.37.1.windows.1
+2.51.0
 


### PR DESCRIPTION
Publication of SVG Editor's Drafts to svgwg.org has resumed. This removes the need to patch inclusion of `DocumentAndElementEventHandlers`.