### PR TITLE
Re-generate patch for ed/css/fill-stroke.json

### DIFF
--- a/ed/csspatches/fill-stroke.json.patch
+++ b/ed/csspatches/fill-stroke.json.patch
@@ -1,6 +1,6 @@
-From c72b6be06992722d6ea75c9f0a161ef873f7b6fd Mon Sep 17 00:00:00 2001
+From 000fc256d1db41f533618670b1afee4ba03849b6 Mon Sep 17 00:00:00 2001
 From: Francois Daoust <fd@tidoust.net>
-Date: Mon, 22 Apr 2024 07:39:29 +0200
+Date: Fri, 12 Dec 2025 10:13:12 +0100
 Subject: [PATCH] Patch not-yet-up-to-date fill-stroke spec properties
 
 The "<'background'> with modifications" value for the `fill` and `stroke`
@@ -17,7 +17,7 @@ https://github.com/w3c/csswg-drafts/issues/3057
  1 file changed, 3 insertions(+), 35 deletions(-)
 
 diff --git a/ed/css/fill-stroke.json b/ed/css/fill-stroke.json
-index f92b290ff..1a9c601fa 100644
+index f231cf2ca3..9999d684e2 100644
 --- a/ed/css/fill-stroke.json
 +++ b/ed/css/fill-stroke.json
 @@ -200,22 +200,6 @@
@@ -26,7 +26,7 @@ index f92b290ff..1a9c601fa 100644
      },
 -    {
 -      "name": "fill",
--      "href": "https://drafts.fxtf.org/fill-stroke-3/#propdef-fill",
+-      "href": "https://drafts.csswg.org/fill-stroke/#propdef-fill",
 -      "value": "<'background'> with modifications",
 -      "initial": "See individual properties",
 -      "appliesTo": "See individual properties",
@@ -42,11 +42,11 @@ index f92b290ff..1a9c601fa 100644
 -    },
      {
        "name": "fill-opacity",
-       "href": "https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-opacity",
+       "href": "https://drafts.csswg.org/fill-stroke/#propdef-fill-opacity",
 @@ -236,7 +220,7 @@
      {
        "name": "stroke-width",
-       "href": "https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-width",
+       "href": "https://drafts.csswg.org/fill-stroke/#propdef-stroke-width",
 -      "value": "<length-percentage>#",
 +      "value": "[<length-percentage> | <number>]#",
        "initial": "1px",
@@ -55,7 +55,7 @@ index f92b290ff..1a9c601fa 100644
 @@ -437,7 +421,7 @@
      {
        "name": "stroke-dasharray",
-       "href": "https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-dasharray",
+       "href": "https://drafts.csswg.org/fill-stroke/#propdef-stroke-dasharray",
 -      "value": "none | <length-percentage>+#",
 +      "value": "none | [<length-percentage> | <number>]+#",
        "initial": "none",
@@ -64,7 +64,7 @@ index f92b290ff..1a9c601fa 100644
 @@ -470,7 +454,7 @@
      {
        "name": "stroke-dashoffset",
-       "href": "https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-dashoffset",
+       "href": "https://drafts.csswg.org/fill-stroke/#propdef-stroke-dashoffset",
 -      "value": "<length-percentage>",
 +      "value": "<length-percentage> | <number>",
        "initial": "0",
@@ -76,7 +76,7 @@ index f92b290ff..1a9c601fa 100644
      },
 -    {
 -      "name": "stroke",
--      "href": "https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke",
+-      "href": "https://drafts.csswg.org/fill-stroke/#propdef-stroke",
 -      "value": "<'background'> with modifications",
 -      "initial": "See individual properties",
 -      "appliesTo": "See individual properties",
@@ -92,7 +92,7 @@ index f92b290ff..1a9c601fa 100644
 -    },
      {
        "name": "stroke-opacity",
-       "href": "https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-opacity",
+       "href": "https://drafts.csswg.org/fill-stroke/#propdef-stroke-opacity",
 -- 
-2.37.1.windows.1
+2.52.0
 


### PR DESCRIPTION
No substantive change other than adjusting the URLs.