### PR TITLE
Drop freeze patch for Filter Effects

### DIFF
--- a/ed/freezepatches/filter-effects-1.json
+++ b/ed/freezepatches/filter-effects-1.json
@@ -1,4 +1,0 @@
-{
-  "commit": "647faa1643647b66b31a505e5b247a8695955352",
-  "pending": "https://github.com/w3c/fxtf-drafts/issues/591"
-}


### PR DESCRIPTION
Spec moved to CSSWG repository, and generation seems back to normal. A patch may still be needed, but the freeze patch should no longer be needed, at least.