### PR TITLE
Adjust permissions in release package workflow

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -4,6 +4,17 @@
 
 name: "Publish @webref package if needed"
 
+permissions:
+  # Required to create/update references (release tags),
+  # includes "read", which is needed to retrieve a PR:
+  # https://docs.github.com/en/rest/git/refs#create-a-reference--fine-grained-access-tokens
+  # https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request--fine-grained-access-tokens
+  contents: write
+
+  # Required for Open ID Connect (OIDC) authentication for npm publication:
+  # https://docs.npmjs.com/trusted-publishers#github-actions-configuration
+  id-token: write
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
The `id-token: write` permission seems required for Open ID Connect (OIDC). Publication to npm cannot succeed without it.
The `contents: write` permission should also be needed to set release tags.

See https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow

Underlying issue: #1739.