### PR TITLE
Bump node version in release workflow

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -28,14 +28,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout latest version of release script
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: main
 
     - name: Setup node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: 20
+        node-version: 24
         cache: 'npm'
 
     - name: Install dependencies


### PR DESCRIPTION
OIDC support requires npm CLI version 11.5.1 or later, and the workflow was still running an older version of Node.js and npm.