### PR TITLE
Drop patches for `<absolute-size>` and `<relative-size>`

### DIFF
--- a/ed/csspatches/syntax-patches.js
+++ b/ed/csspatches/syntax-patches.js
@@ -164,15 +164,8 @@ export default {
     "<integer>": "<number-token>"
   },
 
-  // https://drafts.csswg.org/css2/#value-def-absolute-size
-  // https://drafts.csswg.org/css2/#value-def-relative-size
   // https://drafts.csswg.org/css2/#value-def-shape
   "CSS2": {
-    "<absolute-size>": `
-      xx-small | x-small | small | medium |
-      large | x-large | xx-large
-    `,
-    "<relative-size>": "larger | smaller",
     "<shape>": "rect(<top>, <right>, <bottom>, <left>)"
   },
 


### PR DESCRIPTION
As reported in #1794, these types, initially defined in CSS2, are re-defined (and extended) in `css-fonts-4` but definitions were not properly marked up there. The spec has now been updated, and Webref correctly considers that the definitions in `css-fonts-4` override the definitions in CSS2.

Additionally, the syntax definitions, which could not be extracted from CSS2 for the same reason, can now be automatically extracted as well.

This update drops the syntax patches for the `<absolute-size>` and `<relative-size>` types accordingly.