### PR TITLE
Adjust patches to new payment-handler shortname

### DIFF
--- a/ed/idlpatches/web-based-payment-handler.idl.patch
+++ b/ed/idlpatches/web-based-payment-handler.idl.patch
@@ -8,13 +8,13 @@ Payment Request re-introduced most of the missing interfaces, except the
 underlying problem, see:
 https://github.com/w3c/payment-handler/issues/412
 ---
- ed/idl/payment-handler.idl | 13 +++++++++++++
+ ed/idl/web-based-payment-handler.idl | 13 +++++++++++++
  1 file changed, 13 insertions(+)
 
-diff --git a/ed/idl/payment-handler.idl b/ed/idl/payment-handler.idl
+diff --git a/ed/idl/web-based-payment-handler.idl b/ed/idl/web-based-payment-handler.idl
 index 1f6eaae2b..8aa55e9e9 100644
---- a/ed/idl/payment-handler.idl
-+++ b/ed/idl/payment-handler.idl
+--- a/ed/idl/web-based-payment-handler.idl
++++ b/ed/idl/web-based-payment-handler.idl
 @@ -81,3 +81,16 @@ DOMString? payerPhone;
  AddressInit shippingAddress;
  DOMString? shippingOption;

--- a/tools/amend-event-data.js
+++ b/tools/amend-event-data.js
@@ -442,6 +442,19 @@ const patches = {
       change: { interface: "Event", bubbles: false }
     }
   ],
+  // Pending https://github.com/w3c/ServiceWorker/pull/1816
+  'service-workers': [
+    {
+      pattern: { type: "canmakepayment" },
+      matched: 1,
+      change: { href: "https://w3c.github.io/web-based-payment-handler/#handling-a-canmakepaymentevent" }
+    },
+    {
+      pattern: { type: "paymentrequest" },
+      matched: 1,
+      change: { href: "https://w3c.github.io/web-based-payment-handler/#handling-a-paymentrequestevent" }
+    }
+  ],
   'speech-api': [
     {
       pattern: {


### PR DESCRIPTION
The shortname of the Payment Handler spec changed from `payment-handler` to `web-based-payment-handler`. The IDL patch needed to be renamed accordingly. Events extended in Service Workers need a patch as well so that consolidation logic can merge the events.

Note: Not going to be enough to fix curation, but we'll get there eventually ;)