### PR TITLE
Update link to csstree issue in css-fonts patch

### DIFF
--- a/ed/csspatches/css-fonts.json.patch
+++ b/ed/csspatches/css-fonts.json.patch
@@ -4,8 +4,8 @@ Date: Mon, 5 Jan 2026 09:25:21 +0100
 Subject: [PATCH] Drop `<font-feature-value-type>` type syntax
 
 The syntax is valid but references to at-rules are not supported by CSSTree
-yet. This should be the same problem as that noted in:
-https://github.com/csstree/csstree/issues/345
+yet:
+https://github.com/csstree/csstree/issues/361
 
 The type itself does not appear anywhere, so dropping the syntax shouldn't be
 a big deal in the meantime.


### PR DESCRIPTION
Via #1870. Patch was not linked to the right issue.