### PR TITLE
Security: Shell command injection risk from package directory name in execSync

### DIFF
--- a/tools/bump-packages-minor.js
+++ b/tools/bump-packages-minor.js
@@ -16,11 +16,16 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { loadJSON } from './utils.js';
 const scriptPath = path.dirname(fileURLToPath(import.meta.url));
+const validPackageTypes = ['css', 'css6', 'elements', 'events', 'idl'];
 
 async function checkPackage(type) {
+  if (!validPackageTypes.includes(type)) {
+    throw new Error(`Unknown package type: ${type}`);
+  }
+
   console.log(`Check ${type} package`);
   const packageFile = path.resolve(scriptPath, '..', 'packages', type, 'package.json');
   const packageContents = await loadJSON(packageFile);
@@ -42,8 +47,8 @@ async function checkPackage(type) {
     return;
   }
 
-  const res = execSync(
-    `git ls-files --others --deleted --exclude-standard --directory ed/${type}`,
+  const res = execFileSync('git',
+    ['ls-files', '--others', '--deleted', '--exclude-standard', '--directory', `ed/${type}`],
     { encoding: 'utf8' }).trim();
   if (res) {
     console.log('- new/deleted files found');


### PR DESCRIPTION
## Summary

Security: Shell command injection risk from package directory name in execSync

## Problem

**Severity**: `High` | **File**: `tools/bump-packages-minor.js:L54`

The script interpolates `type` into a shell command: ``execSync(`git ls-files --others --deleted --exclude-standard --directory ed/${type}`)``. `type` comes from directory names under `packages`, which can be influenced by repository content. A crafted folder name containing shell metacharacters could execute arbitrary commands when this script runs.

## Solution

Use `execFileSync('git', ['ls-files', '--others', '--deleted', '--exclude-standard', '--directory', `ed/${type}`])` instead of shell strings. Also validate `type` against expected package names (e.g., `['css','css6','elements','events','idl']`).

## Changes

- `tools/bump-packages-minor.js` (modified)