### PR TITLE
feat(types): add type declarations to all `@webref/*` packages

### DIFF
--- a/packages/css/index.d.ts
+++ b/packages/css/index.d.ts
@@ -98,9 +98,9 @@ export interface CssAtRuleDefinition extends ScopedCssFeatureDefinition {
 }
 
 /**
- * Indexed variant of a CSS at-rule definition returned by {@linkcode index} and
- * {@linkcode indexSync}. The descriptor array is replaced with an object keyed
- * by descriptor name for direct lookups.
+ * Indexed variant of a CSS at-rule definition returned by {@linkcode index}.
+ * The descriptor array is replaced with an object keyed by descriptor name for
+ * direct lookups.
  */
 export interface IndexedCssAtRuleDefinition
   extends Omit<CssAtRuleDefinition, "descriptors"> {
@@ -202,8 +202,7 @@ export interface CssPropertyDefinition extends CssFeatureDefinition {
 }
 
 /**
- * Shape of the consolidated CSS data returned by {@linkcode listAll} and
- * {@linkcode listAllSync}.
+ * Shape of the consolidated CSS data returned by {@linkcode listAll}.
  */
 export interface CssDefinitions {
   /**
@@ -229,8 +228,7 @@ export interface CssDefinitions {
 }
 
 /**
- * Shape of the indexed CSS data returned by {@linkcode index} and
- * {@linkcode indexSync}.
+ * Shape of the indexed CSS data returned by {@linkcode index}.
  */
 export interface IndexedCssDefinitions {
   /**
@@ -264,19 +262,8 @@ export interface IndexedCssDefinitions {
  *
  * @param [options] Optional configuration for loading the JSON file.
  * @returns a Promise that resolves to the consolidated CSS definitions.
- * @see {@linkcode listAllSync} for the synchronous version of this API.
  */
 export function listAll(options?: ListAllOptions): Promise<CssDefinitions>;
-
-/**
- * Synchronously reads and parses the consolidated `css.json` file from the
- * `@webref/css` package.
- *
- * @param [options] Optional configuration for loading the JSON file.
- * @returns the consolidated CSS definitions.
- * @see {@linkcode listAll} for the asynchronous version of this API.
- */
-export function listAllSync(options?: ListAllOptions): CssDefinitions;
 
 /**
  * Builds an object view of the consolidated CSS definitions keyed by feature
@@ -284,25 +271,12 @@ export function listAllSync(options?: ListAllOptions): CssDefinitions;
  *
  * @param [options] Optional configuration for loading the JSON file.
  * @returns a Promise that resolves to the indexed CSS definitions.
- * @see {@linkcode indexSync} for the synchronous version of this API.
  */
 export function index(options?: ListAllOptions): Promise<IndexedCssDefinitions>;
 
-/**
- * Synchronously builds an object view of the consolidated CSS definitions keyed
- * by feature name for easier direct lookups.
- *
- * @param [options] Optional configuration for loading the JSON file.
- * @returns the indexed CSS definitions.
- * @see {@linkcode index} for the asynchronous version of this API.
- */
-export function indexSync(options?: ListAllOptions): IndexedCssDefinitions;
-
 declare const _default: {
   listAll: typeof listAll;
-  listAllSync: typeof listAllSync;
   index: typeof index;
-  indexSync: typeof indexSync;
 };
 
 export default _default;

--- a/packages/css/index.d.ts
+++ b/packages/css/index.d.ts
@@ -1,0 +1,308 @@
+export interface ListAllOptions {
+  /**
+   * Path to the folder containing the `css.json` file to read from. Defaults to
+   * the path of the `@webref/css` package itself. This option mainly exists for
+   * tests and other advanced workflows that need to point the package at a
+   * different copy of the data.
+   *
+   * @default {__dirname}
+   */
+  folder?: string | undefined;
+}
+
+/**
+ * Shared metadata for CSS features exposed by the consolidated `css.json` file.
+ */
+export interface CssFeatureDefinition {
+  /**
+   * The canonical feature name as it appears in the source specification.
+   * Examples include property names, at-rule names, selector names, and
+   * function/type notations.
+   */
+  readonly name: string;
+  /**
+   * Absolute URL to the primary specification definition of the feature.
+   */
+  readonly href: string;
+  /**
+   * Absolute URLs to specifications that extend the base definition.
+   * For most feature kinds this is usually an empty array.
+   */
+  readonly extended: string[];
+  /**
+   * Optional prose excerpt captured near the definition in the specification.
+   * This field is mainly intended for debugging and human inspection.
+   */
+  readonly prose?: string | undefined;
+  /**
+   * Formal syntax for the feature when the specification exposes one.
+   */
+  readonly syntax?: string | undefined;
+}
+
+/**
+ * Base shape for CSS feature definitions that may be scoped to another feature.
+ */
+export interface ScopedCssFeatureDefinition extends CssFeatureDefinition {
+  /**
+   * Names of the CSS features that scope this definition.
+   * For example, a function may only be valid for a given property, or an
+   * at-rule may only be valid when nested under another at-rule.
+   */
+  readonly for?: string[] | undefined;
+}
+
+/**
+ * Descriptor definition attached to a consolidated CSS at-rule entry.
+ */
+export interface CssAtRuleDescriptorDefinition {
+  /**
+   * Descriptor name, as defined in the source specification.
+   */
+  readonly name: string;
+  /**
+   * Absolute URL to the descriptor definition in the specification.
+   */
+  readonly href: string;
+  /**
+   * Name of the at-rule this descriptor belongs to.
+   * @example "@font-face"
+   */
+  readonly for: string;
+  /**
+   * Descriptor initial value when exposed by the specification.
+   */
+  readonly initial?: string | undefined;
+  /**
+   * Descriptor syntax when exposed by the specification.
+   */
+  readonly syntax?: string | undefined;
+  /**
+   * Descriptor type metadata, typically used for media or container features.
+   */
+  readonly type?: string | undefined;
+  /**
+   * Computed value metadata when present in the source specification.
+   */
+  readonly computedValue?: string | undefined;
+}
+
+/**
+ * Consolidated definition for a CSS at-rule.
+ */
+export interface CssAtRuleDefinition extends ScopedCssFeatureDefinition {
+  /**
+   * Descriptors defined for the at-rule.
+   */
+  readonly descriptors: CssAtRuleDescriptorDefinition[];
+}
+
+/**
+ * Indexed variant of a CSS at-rule definition returned by {@linkcode index} and
+ * {@linkcode indexSync}. The descriptor array is replaced with an object keyed
+ * by descriptor name for direct lookups.
+ */
+export interface IndexedCssAtRuleDefinition
+  extends Omit<CssAtRuleDefinition, "descriptors"> {
+  /**
+   * Descriptors indexed by descriptor name.
+   */
+  readonly descriptors: Record<string, CssAtRuleDescriptorDefinition>;
+}
+
+/**
+ * Consolidated definition for a CSS function.
+ */
+export interface CssFunctionDefinition extends ScopedCssFeatureDefinition {}
+
+/**
+ * Consolidated definition for a CSS selector.
+ */
+export interface CssSelectorDefinition extends CssFeatureDefinition {}
+
+/**
+ * Consolidated definition for a CSS type.
+ */
+export interface CssTypeDefinition extends ScopedCssFeatureDefinition {}
+
+/**
+ * Consolidated definition for a CSS property.
+ */
+export interface CssPropertyDefinition extends CssFeatureDefinition {
+  /**
+   * Whether and how the property is animatable, copied from the source
+   * specification when available.
+   */
+  readonly animatable?: string | undefined;
+  /**
+   * Additional animation metadata surfaced by some specifications.
+   */
+  readonly animatableType?: string | undefined;
+  /**
+   * Animation type metadata for the property.
+   */
+  readonly animationType?: string | undefined;
+  /**
+   * "Applies to" metadata from the property definition table.
+   */
+  readonly appliesTo?: string | undefined;
+  /**
+   * Canonical order metadata from the property definition table.
+   */
+  readonly canonicalOrder?: string | undefined;
+  /**
+   * Computed value metadata from the property definition table.
+   */
+  readonly computedValue?: string | undefined;
+  /**
+   * Legacy raw key copied from some sources where the field name includes a
+   * non-breaking space.
+   */
+  readonly "computed\u00A0value"?: string | undefined;
+  /**
+   * Whether the property is inherited, as reported by the source spec.
+   */
+  readonly inherited?: string | undefined;
+  /**
+   * Initial value metadata from the property definition table.
+   */
+  readonly initial?: string | undefined;
+  /**
+   * Name of the canonical property when this entry is a legacy alias.
+   */
+  readonly legacyAliasOf?: string | undefined;
+  /**
+   * Logical property group metadata when exposed by the source spec.
+   */
+  readonly logicalPropertyGroup?: string | undefined;
+  /**
+   * Longhand properties set by this shorthand, in specification order.
+   */
+  readonly longhands?: string[] | undefined;
+  /**
+   * Media group metadata from the property definition table.
+   */
+  readonly media?: string | undefined;
+  /**
+   * Percentage resolution metadata from the property definition table.
+   */
+  readonly percentages?: string | undefined;
+  /**
+   * Reset-only longhands for shorthand properties, in specification order.
+   */
+  readonly resetLonghands?: string[] | undefined;
+  /**
+   * CSSOM attribute names generated for this property.
+   */
+  readonly styleDeclaration: string[];
+  /**
+   * Used value metadata when exposed by the source specification.
+   */
+  readonly usedValue?: string | undefined;
+}
+
+/**
+ * Shape of the consolidated CSS data returned by {@linkcode listAll} and
+ * {@linkcode listAllSync}.
+ */
+export interface CssDefinitions {
+  /**
+   * All known CSS at-rules.
+   */
+  readonly atrules: CssAtRuleDefinition[];
+  /**
+   * All known CSS functions.
+   */
+  readonly functions: CssFunctionDefinition[];
+  /**
+   * All known CSS properties.
+   */
+  readonly properties: CssPropertyDefinition[];
+  /**
+   * All known CSS selectors.
+   */
+  readonly selectors: CssSelectorDefinition[];
+  /**
+   * All known CSS non-terminal types.
+   */
+  readonly types: CssTypeDefinition[];
+}
+
+/**
+ * Shape of the indexed CSS data returned by {@linkcode index} and
+ * {@linkcode indexSync}.
+ */
+export interface IndexedCssDefinitions {
+  /**
+   * At-rules indexed by feature name, or by a disambiguated
+   * `<name> for <scope>` key when needed.
+   */
+  readonly atrules: Record<string, IndexedCssAtRuleDefinition>;
+  /**
+   * Functions indexed by feature name, or by a disambiguated
+   * `<name> for <scope>` key when needed.
+   */
+  readonly functions: Record<string, CssFunctionDefinition>;
+  /**
+   * Properties indexed by property name.
+   */
+  readonly properties: Record<string, CssPropertyDefinition>;
+  /**
+   * Selectors indexed by selector name.
+   */
+  readonly selectors: Record<string, CssSelectorDefinition>;
+  /**
+   * Types indexed by feature name, or by a disambiguated
+   * `<name> for <scope>` key when needed.
+   */
+  readonly types: Record<string, CssTypeDefinition>;
+}
+
+/**
+ * Reads and parses the consolidated `css.json` file from the `@webref/css`
+ * package.
+ *
+ * @param [options] Optional configuration for loading the JSON file.
+ * @returns a Promise that resolves to the consolidated CSS definitions.
+ * @see {@linkcode listAllSync} for the synchronous version of this API.
+ */
+export function listAll(options?: ListAllOptions): Promise<CssDefinitions>;
+
+/**
+ * Synchronously reads and parses the consolidated `css.json` file from the
+ * `@webref/css` package.
+ *
+ * @param [options] Optional configuration for loading the JSON file.
+ * @returns the consolidated CSS definitions.
+ * @see {@linkcode listAll} for the asynchronous version of this API.
+ */
+export function listAllSync(options?: ListAllOptions): CssDefinitions;
+
+/**
+ * Builds an object view of the consolidated CSS definitions keyed by feature
+ * name for easier direct lookups.
+ *
+ * @param [options] Optional configuration for loading the JSON file.
+ * @returns a Promise that resolves to the indexed CSS definitions.
+ * @see {@linkcode indexSync} for the synchronous version of this API.
+ */
+export function index(options?: ListAllOptions): Promise<IndexedCssDefinitions>;
+
+/**
+ * Synchronously builds an object view of the consolidated CSS definitions keyed
+ * by feature name for easier direct lookups.
+ *
+ * @param [options] Optional configuration for loading the JSON file.
+ * @returns the indexed CSS definitions.
+ * @see {@linkcode index} for the asynchronous version of this API.
+ */
+export function indexSync(options?: ListAllOptions): IndexedCssDefinitions;
+
+declare const _default: {
+  listAll: typeof listAll;
+  listAllSync: typeof listAllSync;
+  index: typeof index;
+  indexSync: typeof indexSync;
+};
+
+export default _default;

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -4,13 +4,21 @@
   "version": "8.5.4",
   "repository": {
     "type": "git",
-    "url": "https://github.com/w3c/webref.git"
+    "url": "https://github.com/w3c/webref.git",
+    "directory": "packages/css"
   },
   "bugs": {
     "url": "https://github.com/w3c/webref/issues"
   },
   "license": "MIT",
   "main": "index.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    }
+  },
   "peerDependencies": {
     "css-tree": "^3.2.1"
   }

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -17,7 +17,8 @@
     ".": {
       "types": "./index.d.ts",
       "default": "./index.js"
-    }
+    },
+    "./css.json": "./css.json"
   },
   "peerDependencies": {
     "css-tree": "^3.2.1"

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -18,7 +18,7 @@
       "types": "./index.d.ts",
       "default": "./index.js"
     },
-    "./css.json": "./css.json"
+    "./*": "./*"
   },
   "peerDependencies": {
     "css-tree": "^3.2.1"

--- a/packages/css6/index.d.ts
+++ b/packages/css6/index.d.ts
@@ -1,13 +1,3 @@
-export interface ListAllOptions {
-  /**
-   * Path to the folder that contains the per-spec JSON extracts to read from.
-   * Defaults to the path of the `@webref/css6` package itself.
-   *
-   * @default {__dirname}
-   */
-  folder?: string | undefined;
-}
-
 /**
  * Metadata about the specification a raw CSS extract comes from.
  */
@@ -221,6 +211,16 @@ export interface Css6DefinitionFile {
  */
 export type Css6DefinitionsBySpecification = Record<string, Css6DefinitionFile>;
 
+export interface ListAllOptions {
+  /**
+   * Path to the folder that contains the per-spec JSON extracts to read from.
+   * Defaults to the path of the `@webref/css6` package itself.
+   *
+   * @default {__dirname}
+   */
+  folder?: string | undefined;
+}
+
 /**
  * Reads and parses all raw per-spec CSS extract files in the `@webref/css6`
  * package.
@@ -228,27 +228,13 @@ export type Css6DefinitionsBySpecification = Record<string, Css6DefinitionFile>;
  * @param [options] Optional configuration for locating the JSON files.
  * @returns a Promise that resolves to a map of spec shortnames to raw CSS
  * extract data.
- * @see {@linkcode listAllSync} for the synchronous version of this API.
  */
 export function listAll(
   options?: ListAllOptions,
 ): Promise<Css6DefinitionsBySpecification>;
 
-/**
- * Synchronously reads and parses all raw per-spec CSS extract files in the
- * `@webref/css6` package.
- *
- * @param [options] Optional configuration for locating the JSON files.
- * @returns a map of spec shortnames to raw CSS extract data.
- * @see {@linkcode listAll} for the asynchronous version of this API.
- */
-export function listAllSync(
-  options?: ListAllOptions,
-): Css6DefinitionsBySpecification;
-
 declare const _default: {
   listAll: typeof listAll;
-  listAllSync: typeof listAllSync;
 };
 
 export default _default;

--- a/packages/css6/index.d.ts
+++ b/packages/css6/index.d.ts
@@ -1,0 +1,254 @@
+export interface ListAllOptions {
+  /**
+   * Path to the folder that contains the per-spec JSON extracts to read from.
+   * Defaults to the path of the `@webref/css6` package itself.
+   *
+   * @default {__dirname}
+   */
+  folder?: string | undefined;
+}
+
+/**
+ * Metadata about the specification a raw CSS extract comes from.
+ */
+export interface SpecificationDefinition {
+  /**
+   * Human-readable specification title.
+   */
+  readonly title: string;
+  /**
+   * Canonical URL for the specification extract.
+   */
+  readonly url: string;
+}
+
+/**
+ * Shared recursive value entry shape used throughout the raw CSS v6 extracts.
+ */
+export interface Css6ValueDefinition {
+  /**
+   * Name of the value space or value entry.
+   */
+  readonly name: string;
+  /**
+   * Absolute URL to the definition in the source specification, when available.
+   */
+  readonly href?: string | undefined;
+  /**
+   * Optional prose excerpt captured near the definition.
+   */
+  readonly prose?: string | undefined;
+  /**
+   * Category of the value entry, for example `"value"` or `"type"`.
+   */
+  readonly type?: string | undefined;
+  /**
+   * Raw CSS Value Definition Syntax string associated with the entry.
+   */
+  readonly value?: string | undefined;
+  /**
+   * Nested values defined under this entry.
+   */
+  readonly values?: Css6ValueDefinition[] | undefined;
+}
+
+/**
+ * Descriptor definition nested under a raw CSS at-rule extract.
+ */
+export interface Css6DescriptorDefinition extends Css6ValueDefinition {
+  /**
+   * Name of the at-rule this descriptor belongs to.
+   */
+  readonly for: string;
+  /**
+   * Initial value metadata when exposed by the source specification.
+   */
+  readonly initial?: string | undefined;
+  /**
+   * Computed value metadata when exposed by the source specification.
+   */
+  readonly computedValue?: string | undefined;
+}
+
+/**
+ * Raw at-rule definition from a per-spec CSS extract.
+ */
+export interface Css6AtRuleDefinition extends Css6ValueDefinition {
+  /**
+   * Descriptors defined for the at-rule.
+   */
+  readonly descriptors: Css6DescriptorDefinition[];
+}
+
+/**
+ * Raw property definition from a per-spec CSS extract.
+ */
+export interface Css6PropertyDefinition extends Css6ValueDefinition {
+  /**
+   * Whether and how the property is animatable, copied verbatim from the
+   * specification extract when available.
+   */
+  readonly animatable?: string | undefined;
+  /**
+   * Additional animation metadata surfaced by some extracts.
+   */
+  readonly animatableType?: string | undefined;
+  /**
+   * Animation type metadata from the property definition table.
+   */
+  readonly animationType?: string | undefined;
+  /**
+   * "Applies to" metadata from the property definition table.
+   */
+  readonly appliesTo?: string | undefined;
+  /**
+   * Canonical order metadata from the property definition table.
+   */
+  readonly canonicalOrder?: string | undefined;
+  /**
+   * Computed value metadata from the property definition table.
+   */
+  readonly computedValue?: string | undefined;
+  /**
+   * Legacy raw key copied from some source files where the field name includes
+   * a non-breaking space.
+   */
+  readonly "computed\u00A0value"?: string | undefined;
+  /**
+   * Whether the property is inherited, as reported by the source spec.
+   */
+  readonly inherited?: string | undefined;
+  /**
+   * Initial value metadata from the property definition table.
+   */
+  readonly initial?: string | undefined;
+  /**
+   * Name of the canonical property when this entry is a legacy alias.
+   */
+  readonly legacyAliasOf?: string | undefined;
+  /**
+   * Logical property group metadata when exposed by the source spec.
+   */
+  readonly logicalPropertyGroup?: string | undefined;
+  /**
+   * Media group metadata from the property definition table.
+   */
+  readonly media?: string | undefined;
+  /**
+   * Additional values that extend a previously defined property.
+   */
+  readonly newValues?: string | undefined;
+  /**
+   * Percentage resolution metadata from the property definition table.
+   */
+  readonly percentages?: string | undefined;
+  /**
+   * CSSOM attribute names generated for this property.
+   */
+  readonly styleDeclaration?: string[] | undefined;
+  /**
+   * Used value metadata when exposed by the source specification.
+   */
+  readonly usedValue?: string | undefined;
+}
+
+/**
+ * Warning emitted during curation of a raw CSS extract.
+ */
+export interface Css6Warning {
+  /**
+   * Human-readable warning message.
+   */
+  readonly msg: string;
+  /**
+   * Name of the CSS entry the warning refers to.
+   */
+  readonly name: string;
+  /**
+   * Optional prose excerpt captured near the warning location.
+   */
+  readonly prose?: string | undefined;
+  /**
+   * Optional URL to the source definition.
+   */
+  readonly href?: string | undefined;
+  /**
+   * Category of CSS entry involved in the warning.
+   */
+  readonly type: string;
+  /**
+   * Optional raw value associated with the warning.
+   */
+  readonly value?: string | undefined;
+  /**
+   * Optional scoping feature the warning refers to.
+   */
+  readonly for?: string | undefined;
+}
+
+/**
+ * Raw per-spec CSS extract as exposed by the `@webref/css6` package.
+ */
+export interface Css6DefinitionFile {
+  /**
+   * Metadata about the source specification.
+   */
+  readonly spec: SpecificationDefinition;
+  /**
+   * Raw property definitions defined in the specification.
+   */
+  readonly properties: Css6PropertyDefinition[];
+  /**
+   * Raw at-rule definitions defined in the specification.
+   */
+  readonly atrules: Css6AtRuleDefinition[];
+  /**
+   * Raw selector definitions defined in the specification.
+   */
+  readonly selectors: Css6ValueDefinition[];
+  /**
+   * Raw type and value-space definitions defined in the specification.
+   */
+  readonly values: Css6ValueDefinition[];
+  /**
+   * Optional curation warnings attached to the extract.
+   */
+  readonly warnings?: Css6Warning[] | undefined;
+}
+
+/**
+ * Mapping of specification shortnames to raw CSS extract files.
+ */
+export type Css6DefinitionsBySpecification = Record<string, Css6DefinitionFile>;
+
+/**
+ * Reads and parses all raw per-spec CSS extract files in the `@webref/css6`
+ * package.
+ *
+ * @param [options] Optional configuration for locating the JSON files.
+ * @returns a Promise that resolves to a map of spec shortnames to raw CSS
+ * extract data.
+ * @see {@linkcode listAllSync} for the synchronous version of this API.
+ */
+export function listAll(
+  options?: ListAllOptions,
+): Promise<Css6DefinitionsBySpecification>;
+
+/**
+ * Synchronously reads and parses all raw per-spec CSS extract files in the
+ * `@webref/css6` package.
+ *
+ * @param [options] Optional configuration for locating the JSON files.
+ * @returns a map of spec shortnames to raw CSS extract data.
+ * @see {@linkcode listAll} for the asynchronous version of this API.
+ */
+export function listAllSync(
+  options?: ListAllOptions,
+): Css6DefinitionsBySpecification;
+
+declare const _default: {
+  listAll: typeof listAll;
+  listAllSync: typeof listAllSync;
+};
+
+export default _default;

--- a/packages/css6/package.json
+++ b/packages/css6/package.json
@@ -4,13 +4,21 @@
   "version": "6.25.4",
   "repository": {
     "type": "git",
-    "url": "https://github.com/w3c/webref.git"
+    "url": "https://github.com/w3c/webref.git",
+    "directory": "packages/css6"
   },
   "bugs": {
     "url": "https://github.com/w3c/webref/issues"
   },
   "license": "MIT",
   "main": "index.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    }
+  },
   "peerDependencies": {
     "css-tree": "^3.2.1"
   }

--- a/packages/css6/package.json
+++ b/packages/css6/package.json
@@ -17,7 +17,8 @@
     ".": {
       "types": "./index.d.ts",
       "default": "./index.js"
-    }
+    },
+    "./*": "./*"
   },
   "peerDependencies": {
     "css-tree": "^3.2.1"

--- a/packages/elements/index.d.ts
+++ b/packages/elements/index.d.ts
@@ -1,0 +1,102 @@
+export interface ListAllOptions {
+  /**
+   * Path to the folder that contains the element definition JSON files to read
+   * from. Defaults to the path of the `@webref/elements` package itself.
+   *
+   * @default {__dirname}
+   */
+  folder?: string | undefined;
+}
+
+/**
+ * Metadata about a specification represented in the `@webref/elements`
+ * package.
+ */
+export interface SpecificationDefinition {
+  /**
+   * Human-readable specification title.
+   */
+  readonly title: string;
+  /**
+   * Canonical URL for the specification.
+   */
+  readonly url: string;
+}
+
+/**
+ * Definition of a single markup element exposed by a specification.
+ */
+export interface ElementDefinition {
+  /**
+   * Element local name as defined by the specification.
+   * @example "video"
+   */
+  readonly name: string;
+  /**
+   * Absolute URL to the element definition in the source specification.
+   */
+  readonly href: string;
+  /**
+   * Name of the Web IDL interface implemented by the element, when one exists.
+   */
+  readonly interface?: string | undefined;
+  /**
+   * Whether the element is obsolete.
+   * This property is only present when the value is `true`.
+   */
+  readonly obsolete?: true | undefined;
+}
+
+/**
+ * Collection of element definitions extracted from a single specification.
+ */
+export interface SpecificationElementsDefinition {
+  /**
+   * Metadata about the source specification.
+   */
+  readonly spec: SpecificationDefinition;
+  /**
+   * Elements defined by the specification.
+   */
+  readonly elements: ElementDefinition[];
+}
+
+/**
+ * Mapping of specification shortnames to their element definitions.
+ */
+export type ElementDefinitionsBySpecification = Record<
+  string,
+  SpecificationElementsDefinition
+>;
+
+/**
+ * Reads and parses all element definition files in the `@webref/elements`
+ * package.
+ *
+ * @param [options] Optional configuration for locating the JSON files.
+ * @returns a Promise that resolves to a map of specification shortnames to
+ * element definition data.
+ * @see {@linkcode listAllSync} for the synchronous version of this API.
+ */
+export function listAll(
+  options?: ListAllOptions,
+): Promise<ElementDefinitionsBySpecification>;
+
+/**
+ * Synchronously reads and parses all element definition files in the
+ * `@webref/elements` package.
+ *
+ * @param [options] Optional configuration for locating the JSON files.
+ * @returns a map of specification shortnames to element definition data.
+ * @see {@linkcode listAll} for the asynchronous version of this API.
+ */
+export function listAllSync(
+  options?: ListAllOptions,
+): ElementDefinitionsBySpecification;
+
+declare const _default: {
+  listAll: typeof listAll;
+  listAllSync: typeof listAllSync;
+};
+
+export default _default;

--- a/packages/elements/index.d.ts
+++ b/packages/elements/index.d.ts
@@ -1,13 +1,3 @@
-export interface ListAllOptions {
-  /**
-   * Path to the folder that contains the element definition JSON files to read
-   * from. Defaults to the path of the `@webref/elements` package itself.
-   *
-   * @default {__dirname}
-   */
-  folder?: string | undefined;
-}
-
 /**
  * Metadata about a specification represented in the `@webref/elements`
  * package.
@@ -69,6 +59,16 @@ export type ElementDefinitionsBySpecification = Record<
   SpecificationElementsDefinition
 >;
 
+export interface ListAllOptions {
+  /**
+   * Path to the folder that contains the element definition JSON files to read
+   * from. Defaults to the path of the `@webref/elements` package itself.
+   *
+   * @default {__dirname}
+   */
+  folder?: string | undefined;
+}
+
 /**
  * Reads and parses all element definition files in the `@webref/elements`
  * package.
@@ -76,27 +76,13 @@ export type ElementDefinitionsBySpecification = Record<
  * @param [options] Optional configuration for locating the JSON files.
  * @returns a Promise that resolves to a map of specification shortnames to
  * element definition data.
- * @see {@linkcode listAllSync} for the synchronous version of this API.
  */
 export function listAll(
   options?: ListAllOptions,
 ): Promise<ElementDefinitionsBySpecification>;
 
-/**
- * Synchronously reads and parses all element definition files in the
- * `@webref/elements` package.
- *
- * @param [options] Optional configuration for locating the JSON files.
- * @returns a map of specification shortnames to element definition data.
- * @see {@linkcode listAll} for the asynchronous version of this API.
- */
-export function listAllSync(
-  options?: ListAllOptions,
-): ElementDefinitionsBySpecification;
-
 declare const _default: {
   listAll: typeof listAll;
-  listAllSync: typeof listAllSync;
 };
 
 export default _default;

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -17,6 +17,7 @@
     ".": {
       "types": "./index.d.ts",
       "default": "./index.js"
-    }
+    },
+    "./*": "./*"
   }
 }

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -4,11 +4,19 @@
   "version": "2.7.2",
   "repository": {
     "type": "git",
-    "url": "https://github.com/w3c/webref.git"
+    "url": "https://github.com/w3c/webref.git",
+    "directory": "packages/elements"
   },
   "bugs": {
     "url": "https://github.com/w3c/webref/issues"
   },
   "license": "MIT",
-  "main": "index.js"
+  "main": "index.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    }
+  }
 }

--- a/packages/events/index.d.ts
+++ b/packages/events/index.d.ts
@@ -1,38 +1,3 @@
-export interface ListAllOptions {
-  /**
-   * Path to the folder containing an `events.json` file to read from. Defaults
-   * to the path of the `@webref/events` package itself. This is only intended
-   * for testing purposes, and will rarely be used by end-users of the package.
-   *
-   * @default {__dirname}
-   */
-  folder?: string | undefined;
-}
-
-/**
- * Lists all events defined in the `events.json` file of the `@webref/events`
- * package, along with their associated metadata.
- *
- * @param [options] Optional configuration for listing events.
- * @returns a Promise that resolves to an array of event metadata objects, or
- * rejects with an error if there is an issue reading/parsing the JSON file.
- * @see {@linkcode EventDefinition} for the objects returned by this function.
- * @see {@linkcode listAllSync} for the synchronous version of this function.
- */
-export function listAll(options?: ListAllOptions): Promise<EventDefinition[]>;
-
-/**
- * Synchronously lists all events defined in the `events.json` file of the
- * `@webref/events` package, along with their associated metadata.
- *
- * @param [options] Optional configuration for listing events.
- * @returns an array of event metadata objects.
- * @see {@linkcode EventDefinition} for the objects returned by this function.
- * @see {@linkcode listAll} for the asynchronous version of this function.
- * @throws {Error} If there is an error reading/parsing the JSON file.
- */
-export function listAllSync(options?: ListAllOptions): EventDefinition[];
-
 /**
  * Represents the metadata for a single event target as defined in the
  * `events.json` file of the `@webref/events` package.
@@ -134,3 +99,31 @@ export interface EventDefinition {
    */
   readonly extendedIn?: SpecificationReference[] | undefined;
 }
+
+export interface ListAllOptions {
+  /**
+   * Path to the folder containing an `events.json` file to read from. Defaults
+   * to the path of the `@webref/events` package itself. This is only intended
+   * for testing purposes, and will rarely be used by end-users of the package.
+   *
+   * @default {__dirname}
+   */
+  folder?: string | undefined;
+}
+
+/**
+ * Lists all events defined in the `events.json` file of the `@webref/events`
+ * package, along with their associated metadata.
+ *
+ * @param [options] Optional configuration for listing events.
+ * @returns a Promise that resolves to an array of event metadata objects, or
+ * rejects with an error if there is an issue reading/parsing the JSON file.
+ * @see {@linkcode EventDefinition} for the objects returned by this function.
+ */
+export function listAll(options?: ListAllOptions): Promise<EventDefinition[]>;
+
+declare const _default: {
+  listAll: typeof listAll;
+};
+
+export default _default;

--- a/packages/events/index.d.ts
+++ b/packages/events/index.d.ts
@@ -1,0 +1,136 @@
+export interface ListAllOptions {
+  /**
+   * Path to the folder containing an `events.json` file to read from. Defaults
+   * to the path of the `@webref/events` package itself. This is only intended
+   * for testing purposes, and will rarely be used by end-users of the package.
+   *
+   * @default {__dirname}
+   */
+  folder?: string | undefined;
+}
+
+/**
+ * Lists all events defined in the `events.json` file of the `@webref/events`
+ * package, along with their associated metadata.
+ *
+ * @param [options] Optional configuration for listing events.
+ * @returns a Promise that resolves to an array of event metadata objects, or
+ * rejects with an error if there is an issue reading/parsing the JSON file.
+ * @see {@linkcode EventDefinition} for the objects returned by this function.
+ * @see {@linkcode listAllSync} for the synchronous version of this function.
+ */
+export function listAll(options?: ListAllOptions): Promise<EventDefinition[]>;
+
+/**
+ * Synchronously lists all events defined in the `events.json` file of the
+ * `@webref/events` package, along with their associated metadata.
+ *
+ * @param [options] Optional configuration for listing events.
+ * @returns an array of event metadata objects.
+ * @see {@linkcode EventDefinition} for the objects returned by this function.
+ * @see {@linkcode listAll} for the asynchronous version of this function.
+ * @throws {Error} If there is an error reading/parsing the JSON file.
+ */
+export function listAllSync(options?: ListAllOptions): EventDefinition[];
+
+/**
+ * Represents the metadata for a single event target as defined in the
+ * `events.json` file of the `@webref/events` package.
+ */
+export interface EventTargetDefinition {
+  /**
+   * The name of the event target. Corresponds to the interface name of the
+   * `EventTarget` found in the `target` property of the event definition.
+   * @example "HTMLElement"
+   */
+  readonly target: string;
+  /**
+   * Whether or not the event bubbles. Corresponds to the `bubbles` property of
+   * the `Event` interface in the DOM API.
+   */
+  readonly bubbles?: boolean | undefined;
+  /**
+   * An array of strings representing the path of event targets that the event
+   * bubbles through.
+   * @example ["Node", "Document", "Window"]
+   */
+  readonly bubblesPath?: string[] | undefined;
+}
+
+/**
+ * Metadata regarding the source of an event definition, including an optional
+ * URL to the specification text and free-form source format description.
+ */
+export interface EventSourceDefinition {
+  /**
+   * The format of the source from which the event definition was extracted.
+   * This is a free-form string that describes the type of source (e.g.,
+   * "summary table", "IDL eventHandler", etc.).
+   * @example "fire an event phrasing"
+   */
+  readonly format: string;
+  /**
+   * An optional URL to the specification text from which the event definition was extracted.
+   * @example "https://w3c.github.io/uievents/#events-click"
+   */
+  readonly href?: string | undefined;
+}
+
+/**
+ * Represents a specification reference in the context of an event definition.
+ */
+export interface SpecificationReference {
+  /**
+   * An identifier for the specification referenced, in URL-safe slug format.
+   * @example "edit-context"
+   */
+  readonly spec: string;
+  /**
+   * An optional URL to the specification text for the referenced specification.
+   * @example "https://w3c.github.io/edit-context/#update-the-editcontext"
+   */
+  readonly href?: string | undefined;
+}
+
+/**
+ * Represents the metadata for a single event as defined in the `events.json`
+ * file of the `@webref/events` package.
+ */
+export interface EventDefinition {
+  /**
+   * An object representing the source of the event, along with its associated
+   * metadata.
+   */
+  readonly src: EventSourceDefinition;
+  /**
+   * The type of the event. Corresponds to the `type` property of the `Event`
+   * interface in the DOM API.
+   * @example "click"
+   */
+  readonly type: string;
+  /**
+   * The specification URL where the event is defined.
+   * @example "https://w3c.github.io/uievents/#events-click"
+   */
+  readonly href: string;
+  /**
+   * The name of the interface that defines the event.
+   * @example "MouseEvent"
+   */
+  readonly interface: string;
+  /**
+   * An array of objects representing the targets that can dispatch this event,
+   * along with their associated metadata.
+   */
+  readonly targets: EventTargetDefinition[];
+  /**
+   * Whether or not the event is cancelable. Corresponds to the `cancelable`
+   * property of the `Event` interface in the DOM API.
+   */
+  readonly cancelable?: boolean | undefined;
+  /**
+   * An array of specification references for specifications that extend the
+   * definition of this event.
+   */
+  readonly extendedIn?: SpecificationReference[] | undefined;
+}

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -4,11 +4,19 @@
   "version": "1.22.2",
   "repository": {
     "type": "git",
-    "url": "https://github.com/w3c/webref.git"
+    "url": "https://github.com/w3c/webref.git",
+    "directory": "packages/events"
   },
   "bugs": {
     "url": "https://github.com/w3c/webref/issues"
   },
   "license": "MIT",
-  "main": "index.js"
+  "types": "index.d.ts",
+  "main": "index.js",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    }
+  }
 }

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -17,6 +17,7 @@
     ".": {
       "types": "./index.d.ts",
       "default": "./index.js"
-    }
+    },
+    "./*": "./*"
   }
 }

--- a/packages/idl/index.d.ts
+++ b/packages/idl/index.d.ts
@@ -111,8 +111,8 @@ export interface WebIdlDefinition {
 export type WebIdlParseResult = WebIdlDefinition[];
 
 /**
- * File handle returned by {@linkcode listAll} and {@linkcode listAllSync} for a
- * single `.idl` file in the package.
+ * File handle returned by {@linkcode listAll} for a single `.idl` file in the
+ * package.
  */
 export interface IDLFileDefinition {
   /**
@@ -132,17 +132,9 @@ export interface IDLFileDefinition {
    */
   text(): Promise<string>;
   /**
-   * Synchronously reads the raw IDL source text.
-   */
-  textSync(): string;
-  /**
    * Asynchronously parses the IDL source with `webidl2.parse`.
    */
   parse(): Promise<WebIdlParseResult>;
-  /**
-   * Synchronously parses the IDL source with `webidl2.parse`.
-   */
-  parseSync(): WebIdlParseResult;
 }
 
 /**
@@ -162,19 +154,8 @@ export type ParsedIDLMap = Record<string, WebIdlParseResult>;
  * @param [options] Optional configuration for locating the `.idl` files.
  * @returns a Promise that resolves to a map of specification shortnames to file
  * handles.
- * @see {@linkcode listAllSync} for the synchronous version of this API.
  */
 export function listAll(options?: ListAllOptions): Promise<IDLFileMap>;
-
-/**
- * Synchronously reads all `.idl` files in the `@webref/idl` package and
- * returns lazy file handles for them.
- *
- * @param [options] Optional configuration for locating the `.idl` files.
- * @returns a map of specification shortnames to file handles.
- * @see {@linkcode listAll} for the asynchronous version of this API.
- */
-export function listAllSync(options?: ListAllOptions): IDLFileMap;
 
 /**
  * Reads and parses every `.idl` file in the `@webref/idl` package with
@@ -183,25 +164,12 @@ export function listAllSync(options?: ListAllOptions): IDLFileMap;
  * @param [options] Optional configuration for locating the `.idl` files.
  * @returns a Promise that resolves to a map of specification shortnames to
  * parsed ASTs.
- * @see {@linkcode parseAllSync} for the synchronous version of this API.
  */
 export function parseAll(options?: ListAllOptions): Promise<ParsedIDLMap>;
 
-/**
- * Synchronously reads and parses every `.idl` file in the `@webref/idl`
- * package with `webidl2.parse`.
- *
- * @param [options] Optional configuration for locating the `.idl` files.
- * @returns a map of specification shortnames to parsed ASTs.
- * @see {@linkcode parseAll} for the asynchronous version of this API.
- */
-export function parseAllSync(options?: ListAllOptions): ParsedIDLMap;
-
 declare const _default: {
   listAll: typeof listAll;
-  listAllSync: typeof listAllSync;
   parseAll: typeof parseAll;
-  parseAllSync: typeof parseAllSync;
 };
 
 export default _default;

--- a/packages/idl/index.d.ts
+++ b/packages/idl/index.d.ts
@@ -1,120 +1,10 @@
-export interface ListAllOptions {
-  /**
-   * Path to the folder containing `.idl` files to read from. Defaults to the
-   * path of the `@webref/idl` package itself.
-   *
-   * @default {__dirname}
-   */
-  folder?: string | undefined;
-}
-
-/**
- * Partial description of a Web IDL type node as returned by `webidl2.parse`.
- * The parser exposes a richer structure than this interface captures, so an
- * index signature is included for forwards compatibility with new node fields.
- */
-export interface WebIdlTypeDescription {
-  /**
-   * Parser-specific type tag for the type node.
-   */
-  readonly type?: string | null | undefined;
-  /**
-   * Generic wrapper name when the type is generic, for example `Promise`.
-   */
-  readonly generic?: string | undefined;
-  /**
-   * Whether the type is nullable.
-   */
-  readonly nullable?: boolean | undefined;
-  /**
-   * Whether the type is a union.
-   */
-  readonly union?: boolean | undefined;
-  /**
-   * Extended attributes attached to the type node.
-   */
-  readonly extAttrs?: WebIdlDefinition[] | undefined;
-  /**
-   * Nested subtype information when exposed by the parser.
-   */
-  readonly subtype?: WebIdlTypeDescription[] | undefined;
-  /**
-   * Underlying IDL type description, which may itself be nested.
-   */
-  readonly idlType?:
-    | string
-    | WebIdlTypeDescription
-    | WebIdlTypeDescription[]
-    | undefined;
-  /**
-   * Additional parser-specific fields surfaced by `webidl2`.
-   */
-  readonly [key: string]: unknown;
-}
-
-/**
- * Partial description of a Web IDL AST node returned by `webidl2.parse`.
- * The parser exposes a broad set of node variants; this interface models the
- * fields that callers most commonly inspect while remaining open-ended.
- */
-export interface WebIdlDefinition {
-  /**
-   * Parser-specific type tag for the AST node.
-   * @example "interface"
-   */
-  readonly type: string;
-  /**
-   * Node name when the AST node represents a named Web IDL construct.
-   */
-  readonly name?: string | undefined;
-  /**
-   * Inheritance target for interface-like definitions, when present.
-   */
-  readonly inheritance?: string | null | undefined;
-  /**
-   * Whether the definition is marked as partial.
-   */
-  readonly partial?: boolean | undefined;
-  /**
-   * Member nodes nested under interface-like definitions.
-   */
-  readonly members?: WebIdlDefinition[] | undefined;
-  /**
-   * Argument nodes nested under operation-like definitions.
-   */
-  readonly arguments?: WebIdlDefinition[] | undefined;
-  /**
-   * Extended attributes attached to the definition.
-   */
-  readonly extAttrs?: WebIdlDefinition[] | undefined;
-  /**
-   * IDL type information attached to the definition, when present.
-   */
-  readonly idlType?:
-    | string
-    | WebIdlTypeDescription
-    | WebIdlTypeDescription[]
-    | undefined;
-  /**
-   * Default value metadata attached to arguments and dictionary fields.
-   */
-  readonly default?: WebIdlDefinition | undefined;
-  /**
-   * Additional parser-specific fields surfaced by `webidl2`.
-   */
-  readonly [key: string]: unknown;
-}
-
-/**
- * Parsed AST returned by `webidl2.parse`.
- */
-export type WebIdlParseResult = WebIdlDefinition[];
+import * as WebIDL2 from "webidl2";
 
 /**
  * File handle returned by {@linkcode listAll} for a single `.idl` file in the
- * package.
+ * package.`
  */
-export interface IDLFileDefinition {
+export interface IDLFile {
   /**
    * File name, including the `.idl` extension.
    */
@@ -132,40 +22,44 @@ export interface IDLFileDefinition {
    */
   text(): Promise<string>;
   /**
-   * Asynchronously parses the IDL source with `webidl2.parse`.
+   * Asynchronously parses the IDL source with `WebIDL2.parse`.
    */
-  parse(): Promise<WebIdlParseResult>;
+  parse(): Promise<WebIDL2.IDLRootType[]>;
 }
 
 /**
- * Mapping of specification shortnames to lazily readable IDL file handles.
+ * Options for locating `.idl` files in the `@webref/idl` package, used by the
+ * {@linkcode listAll} and {@linkcode parseAll} functions.
  */
-export type IDLFileMap = Record<string, IDLFileDefinition>;
-
-/**
- * Mapping of specification shortnames to parsed Web IDL ASTs.
- */
-export type ParsedIDLMap = Record<string, WebIdlParseResult>;
+export interface ListAllOptions {
+  /**
+   * Path to the folder containing `.idl` files to read from. Defaults to the
+   * path of the `@webref/idl` package itself.
+   *
+   * @default {__dirname}
+   */
+  folder?: string | undefined;
+}
 
 /**
  * Reads all `.idl` files in the `@webref/idl` package and returns lazy file
  * handles for them.
  *
  * @param [options] Optional configuration for locating the `.idl` files.
- * @returns a Promise that resolves to a map of specification shortnames to file
- * handles.
+ * @returns a Promise that resolves to a map of specification shortnames to
+ * file handles.
  */
-export function listAll(options?: ListAllOptions): Promise<IDLFileMap>;
+export function listAll(options?: ListAllOptions): Promise<Record<string, IDLFile>>;
 
 /**
  * Reads and parses every `.idl` file in the `@webref/idl` package with
- * `webidl2.parse`.
+ * {@linkcode WebIDL2.parse}.
  *
  * @param [options] Optional configuration for locating the `.idl` files.
  * @returns a Promise that resolves to a map of specification shortnames to
  * parsed ASTs.
  */
-export function parseAll(options?: ListAllOptions): Promise<ParsedIDLMap>;
+export function parseAll(options?: ListAllOptions): Promise<Record<string, WebIDL2.IDLRootType[]>>;
 
 declare const _default: {
   listAll: typeof listAll;
@@ -173,3 +67,5 @@ declare const _default: {
 };
 
 export default _default;
+
+export type * from "webidl2";

--- a/packages/idl/index.d.ts
+++ b/packages/idl/index.d.ts
@@ -49,7 +49,9 @@ export interface ListAllOptions {
  * @returns a Promise that resolves to a map of specification shortnames to
  * file handles.
  */
-export function listAll(options?: ListAllOptions): Promise<Record<string, IDLFile>>;
+export function listAll(
+  options?: ListAllOptions,
+): Promise<Record<string, IDLFile>>;
 
 /**
  * Reads and parses every `.idl` file in the `@webref/idl` package with
@@ -59,7 +61,9 @@ export function listAll(options?: ListAllOptions): Promise<Record<string, IDLFil
  * @returns a Promise that resolves to a map of specification shortnames to
  * parsed ASTs.
  */
-export function parseAll(options?: ListAllOptions): Promise<Record<string, WebIDL2.IDLRootType[]>>;
+export function parseAll(
+  options?: ListAllOptions,
+): Promise<Record<string, WebIDL2.IDLRootType[]>>;
 
 declare const _default: {
   listAll: typeof listAll;

--- a/packages/idl/index.d.ts
+++ b/packages/idl/index.d.ts
@@ -1,0 +1,207 @@
+export interface ListAllOptions {
+  /**
+   * Path to the folder containing `.idl` files to read from. Defaults to the
+   * path of the `@webref/idl` package itself.
+   *
+   * @default {__dirname}
+   */
+  folder?: string | undefined;
+}
+
+/**
+ * Partial description of a Web IDL type node as returned by `webidl2.parse`.
+ * The parser exposes a richer structure than this interface captures, so an
+ * index signature is included for forwards compatibility with new node fields.
+ */
+export interface WebIdlTypeDescription {
+  /**
+   * Parser-specific type tag for the type node.
+   */
+  readonly type?: string | null | undefined;
+  /**
+   * Generic wrapper name when the type is generic, for example `Promise`.
+   */
+  readonly generic?: string | undefined;
+  /**
+   * Whether the type is nullable.
+   */
+  readonly nullable?: boolean | undefined;
+  /**
+   * Whether the type is a union.
+   */
+  readonly union?: boolean | undefined;
+  /**
+   * Extended attributes attached to the type node.
+   */
+  readonly extAttrs?: WebIdlDefinition[] | undefined;
+  /**
+   * Nested subtype information when exposed by the parser.
+   */
+  readonly subtype?: WebIdlTypeDescription[] | undefined;
+  /**
+   * Underlying IDL type description, which may itself be nested.
+   */
+  readonly idlType?:
+    | string
+    | WebIdlTypeDescription
+    | WebIdlTypeDescription[]
+    | undefined;
+  /**
+   * Additional parser-specific fields surfaced by `webidl2`.
+   */
+  readonly [key: string]: unknown;
+}
+
+/**
+ * Partial description of a Web IDL AST node returned by `webidl2.parse`.
+ * The parser exposes a broad set of node variants; this interface models the
+ * fields that callers most commonly inspect while remaining open-ended.
+ */
+export interface WebIdlDefinition {
+  /**
+   * Parser-specific type tag for the AST node.
+   * @example "interface"
+   */
+  readonly type: string;
+  /**
+   * Node name when the AST node represents a named Web IDL construct.
+   */
+  readonly name?: string | undefined;
+  /**
+   * Inheritance target for interface-like definitions, when present.
+   */
+  readonly inheritance?: string | null | undefined;
+  /**
+   * Whether the definition is marked as partial.
+   */
+  readonly partial?: boolean | undefined;
+  /**
+   * Member nodes nested under interface-like definitions.
+   */
+  readonly members?: WebIdlDefinition[] | undefined;
+  /**
+   * Argument nodes nested under operation-like definitions.
+   */
+  readonly arguments?: WebIdlDefinition[] | undefined;
+  /**
+   * Extended attributes attached to the definition.
+   */
+  readonly extAttrs?: WebIdlDefinition[] | undefined;
+  /**
+   * IDL type information attached to the definition, when present.
+   */
+  readonly idlType?:
+    | string
+    | WebIdlTypeDescription
+    | WebIdlTypeDescription[]
+    | undefined;
+  /**
+   * Default value metadata attached to arguments and dictionary fields.
+   */
+  readonly default?: WebIdlDefinition | undefined;
+  /**
+   * Additional parser-specific fields surfaced by `webidl2`.
+   */
+  readonly [key: string]: unknown;
+}
+
+/**
+ * Parsed AST returned by `webidl2.parse`.
+ */
+export type WebIdlParseResult = WebIdlDefinition[];
+
+/**
+ * File handle returned by {@linkcode listAll} and {@linkcode listAllSync} for a
+ * single `.idl` file in the package.
+ */
+export interface IDLFileDefinition {
+  /**
+   * File name, including the `.idl` extension.
+   */
+  readonly filename: string;
+  /**
+   * Specification shortname derived from the file name.
+   */
+  readonly shortname: string;
+  /**
+   * Absolute path to the underlying `.idl` file on disk.
+   */
+  readonly path: string;
+  /**
+   * Asynchronously reads the raw IDL source text.
+   */
+  text(): Promise<string>;
+  /**
+   * Synchronously reads the raw IDL source text.
+   */
+  textSync(): string;
+  /**
+   * Asynchronously parses the IDL source with `webidl2.parse`.
+   */
+  parse(): Promise<WebIdlParseResult>;
+  /**
+   * Synchronously parses the IDL source with `webidl2.parse`.
+   */
+  parseSync(): WebIdlParseResult;
+}
+
+/**
+ * Mapping of specification shortnames to lazily readable IDL file handles.
+ */
+export type IDLFileMap = Record<string, IDLFileDefinition>;
+
+/**
+ * Mapping of specification shortnames to parsed Web IDL ASTs.
+ */
+export type ParsedIDLMap = Record<string, WebIdlParseResult>;
+
+/**
+ * Reads all `.idl` files in the `@webref/idl` package and returns lazy file
+ * handles for them.
+ *
+ * @param [options] Optional configuration for locating the `.idl` files.
+ * @returns a Promise that resolves to a map of specification shortnames to file
+ * handles.
+ * @see {@linkcode listAllSync} for the synchronous version of this API.
+ */
+export function listAll(options?: ListAllOptions): Promise<IDLFileMap>;
+
+/**
+ * Synchronously reads all `.idl` files in the `@webref/idl` package and
+ * returns lazy file handles for them.
+ *
+ * @param [options] Optional configuration for locating the `.idl` files.
+ * @returns a map of specification shortnames to file handles.
+ * @see {@linkcode listAll} for the asynchronous version of this API.
+ */
+export function listAllSync(options?: ListAllOptions): IDLFileMap;
+
+/**
+ * Reads and parses every `.idl` file in the `@webref/idl` package with
+ * `webidl2.parse`.
+ *
+ * @param [options] Optional configuration for locating the `.idl` files.
+ * @returns a Promise that resolves to a map of specification shortnames to
+ * parsed ASTs.
+ * @see {@linkcode parseAllSync} for the synchronous version of this API.
+ */
+export function parseAll(options?: ListAllOptions): Promise<ParsedIDLMap>;
+
+/**
+ * Synchronously reads and parses every `.idl` file in the `@webref/idl`
+ * package with `webidl2.parse`.
+ *
+ * @param [options] Optional configuration for locating the `.idl` files.
+ * @returns a map of specification shortnames to parsed ASTs.
+ * @see {@linkcode parseAll} for the asynchronous version of this API.
+ */
+export function parseAllSync(options?: ListAllOptions): ParsedIDLMap;
+
+declare const _default: {
+  listAll: typeof listAll;
+  listAllSync: typeof listAllSync;
+  parseAll: typeof parseAll;
+  parseAllSync: typeof parseAllSync;
+};
+
+export default _default;

--- a/packages/idl/package.json
+++ b/packages/idl/package.json
@@ -17,7 +17,8 @@
     ".": {
       "types": "./index.d.ts",
       "default": "./index.js"
-    }
+    },
+    "./*": "./*"
   },
   "peerDependencies": {
     "webidl2": "^24.5.0"

--- a/packages/idl/package.json
+++ b/packages/idl/package.json
@@ -4,13 +4,21 @@
   "version": "3.75.3",
   "repository": {
     "type": "git",
-    "url": "https://github.com/w3c/webref.git"
+    "url": "https://github.com/w3c/webref.git",
+    "directory": "packages/idl"
   },
   "bugs": {
     "url": "https://github.com/w3c/webref/issues"
   },
   "license": "MIT",
+  "types": "index.d.ts",
   "main": "index.js",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    }
+  },
   "peerDependencies": {
     "webidl2": "^24.5.0"
   }

--- a/packages/idl/package.json
+++ b/packages/idl/package.json
@@ -22,5 +22,8 @@
   },
   "peerDependencies": {
     "webidl2": "^24.5.0"
+  },
+  "devDependencies": {
+    "@types/webidl2": "^24.4.3"
   }
 }


### PR DESCRIPTION
Closes #1900.

## Overview

This PR contains just the type-related changes from the original draft PR #1901, applied to the latest commit on the main branch. In addition to new `index.d.ts` files, each `package.json` manifest has also been updated with a new `types` and `exports` fields.

## Changes

- feat(types): add type declarations for @webref/css package
- feat(types): update @webref/css package manifest
- feat(types): add types to @webref/css6 package
- feat(types): add type declarations for @webref/elements package
- feat(types): add type declarations for @webref/events package
- feat(types): add type declarations for @webref/idl package
