### PR TITLE
Add interfaces for Prompt API events

### DIFF
--- a/tools/amend-event-data.js
+++ b/tools/amend-event-data.js
@@ -410,6 +410,14 @@ const patches = {
       }
     }
   ],
+  // No event processing in the Prompt API for now
+  'prompt-api': [
+    {
+      pattern: { type: /overflow$/ },
+      matched: 2,
+      change: { interface: "Event" }
+    }
+  ],
   'savedata': [
     {
       pattern: { type: "change" },


### PR DESCRIPTION
The spec does not yet specify any event processing. Using `Event` for now.