### PR TITLE
Re-generate patch for ed/idl/SVG.idl

### DIFF
--- a/ed/idlpatches/SVG.idl.patch
+++ b/ed/idlpatches/SVG.idl.patch
@@ -1,21 +1,31 @@
-From 53764db6d64660599a2a5df600646612bc5e9441 Mon Sep 17 00:00:00 2001
+From 10569f42edbd3e03ee2aa3968225c1af8ffaa3c6 Mon Sep 17 00:00:00 2001
 From: Francois Daoust <fd@tidoust.net>
-Date: Fri, 3 Apr 2026 08:46:48 +0200
+Date: Tue, 5 May 2026 11:02:49 +0200
 Subject: [PATCH] Fix IDL of SVG spec
 
 HTMLHyperlinkElementUtils: https://github.com/w3c/svgwg/issues/312
+HTMLOrSVGOrMathMLElement: https://github.com/w3c/svgwg/pull/1103
 
 Also drop `SVGPathElement`, now that SVG Paths is also being crawled, pending
 clarification of status between SVG 2 and SVG Paths.
 ---
- ed/idl/SVG.idl | 19 ++++++++++++++-----
- 1 file changed, 14 insertions(+), 5 deletions(-)
+ ed/idl/SVG.idl | 21 +++++++++++++++------
+ 1 file changed, 15 insertions(+), 6 deletions(-)
 
 diff --git a/ed/idl/SVG.idl b/ed/idl/SVG.idl
-index 1cfc167cc6..3f66f5164b 100644
+index 6ab66cc7ed..22c73736ef 100644
 --- a/ed/idl/SVG.idl
 +++ b/ed/idl/SVG.idl
-@@ -419,10 +419,6 @@ interface SVGAnimatedPreserveAspectRatio {
+@@ -13,7 +13,7 @@ interface SVGElement : Element {
+ };
+ 
+ SVGElement includes GlobalEventHandlers;
+-SVGElement includes HTMLOrSVGElement;
++SVGElement includes HTMLOrSVGOrMathMLElement;
+ 
+ dictionary SVGBoundingBoxOptions {
+   boolean fill = true;
+@@ -413,10 +413,6 @@ interface SVGAnimatedPreserveAspectRatio {
    [SameObject] readonly attribute SVGPreserveAspectRatio animVal;
  };
  
@@ -26,7 +36,7 @@ index 1cfc167cc6..3f66f5164b 100644
  [Exposed=Window]
  interface SVGRectElement : SVGGeometryElement {
    [SameObject] readonly attribute SVGAnimatedLength x;
-@@ -672,7 +668,20 @@ interface SVGAElement : SVGGraphicsElement {
+@@ -666,7 +662,20 @@ interface SVGAElement : SVGGraphicsElement {
  };
  
  SVGAElement includes SVGURIReference;
@@ -49,5 +59,5 @@ index 1cfc167cc6..3f66f5164b 100644
  [Exposed=Window]
  interface SVGViewElement : SVGElement {};
 -- 
-2.53.0
+2.54.0
 


### PR DESCRIPTION
Make use of the new `HTMLOrSVGOrMathMLElement`, pending https://github.com/w3c/svgwg/pull/1103