### PR TITLE
Drop syntax patch for `<basic-shape>`

### DIFF
--- a/ed/csspatches/syntax-patches.js
+++ b/ed/csspatches/syntax-patches.js
@@ -115,15 +115,6 @@ export default {
     }
   },
 
-  // https://drafts.csswg.org/css-shapes-1/#supported-basic-shapes
-  "css-shapes-1": {
-    "<basic-shape>": `
-      <basic-shape-rect> |
-      <circle()> | <ellipse()> | <polygon()> |
-      <path()> | <shape()>
-    `
-  },
-
   // https://drafts.csswg.org/css-syntax-3/#the-anb-type
   "css-syntax-3": {
     "<n-dimension>": "<dimension-token>",


### PR DESCRIPTION
Syntax was now added to the spec, although note that `<shape()>` is still missing for now, see https://github.com/w3c/csswg-drafts/pull/13894