### PR TITLE
Bump versions in workflows, enable dependabot check of actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,9 @@ updates:
     interval: daily
     time: '10:00'
   open-pull-requests-limit: 10
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    time: '10:00'
+  open-pull-requests-limit: 10

--- a/.github/workflows/clean-patches.yml
+++ b/.github/workflows/clean-patches.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout webref
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: 20
+        node-version: 24
         cache: 'npm'
 
     - name: Install dependencies
@@ -26,7 +26,7 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Create PR to drop patches from repo if needed
-      uses: peter-evans/create-pull-request@v5
+      uses: peter-evans/create-pull-request@v8.1.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -9,15 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout webref
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Setup node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: 20
+        node-version: 24
         cache: 'npm'
     - name: Run clean up
       run: node tools/clean-abandoned-files.js
-    - uses: peter-evans/create-pull-request@v5
+    - uses: peter-evans/create-pull-request@v8.1.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/curate.yml
+++ b/.github/workflows/curate.yml
@@ -23,16 +23,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout webref
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         # Need to checkout all history as curation job also needs to access
         # the curated branch
         fetch-depth: 0
 
     - name: Setup node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: 20
+        node-version: 24
         cache: 'npm'
 
     - name: Install dependencies
@@ -51,7 +51,7 @@ jobs:
         node tools/commit-curated.js curated stay-on-curated-branch
 
     - name: Push changes to curated branch
-      uses: ad-m/github-push-action@v0.8.0
+      uses: ad-m/github-push-action@v1.1.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         branch: curated

--- a/.github/workflows/request-pr-review.yml
+++ b/.github/workflows/request-pr-review.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout webref
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: 20
+        node-version: 24
         cache: 'npm'
 
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,13 +6,13 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         # Need to checkout all history for curation job
         fetch-depth: 0
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
-        node-version: 20
+        node-version: 24
         cache: 'npm'
     - name: Install dependencies
       run: npm ci

--- a/.github/workflows/update-ed.yml
+++ b/.github/workflows/update-ed.yml
@@ -15,12 +15,12 @@ jobs:
       run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
 
     - name: Checkout repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: 20
+        node-version: 24
         cache: 'npm'
 
     - name: Install dependencies
@@ -36,7 +36,7 @@ jobs:
     # Update another Webref checkout to reduce the chances that the version we
     # checked out is no longer in sync with origin by the time the crawl is over
     - name: Checkout webref once more
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         path: webref
 

--- a/.github/workflows/update-tr.yml
+++ b/.github/workflows/update-tr.yml
@@ -15,12 +15,12 @@ jobs:
       run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
 
     - name: Checkout repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: 20
+        node-version: 24
         cache: 'npm'
 
     - name: Install dependencies
@@ -34,7 +34,7 @@ jobs:
     # Update another Webref checkout to reduce the chances that the version we
     # checked out is no longer in sync with origin by the time the crawl is over
     - name: Checkout webref
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         path: webref
 


### PR DESCRIPTION
This bumps the version of Node.js used in workflows to v24 (latest version of Reffy requires >=v22.19.0), and bumps the versions of actions used in the workflows.

This also requests Dependabot to check actions used in workflows. Coz' why not. We may adjust afterwards if that creates too much maintenance burden for not much added value.