### PR TITLE
`@webref/xref`: Support lookup of non percent-encoded URLs

### DIFF
--- a/packages-auto/xref/index.js
+++ b/packages-auto/xref/index.js
@@ -63,7 +63,7 @@ function setupExtracts(type, rootFolder) {
         if (entry.alternateIds) {
           for (const id of entry.alternateIds) {
             const url = new URL(entry.href);
-            url.hash = id;
+            url.hash = encodeURIComponent(id);
             const href = url.toString();
             indexUrl(href, { source: 'headings', entry });
           }
@@ -100,8 +100,27 @@ export function setup(rootFolder = scriptPath) {
  */
 export function lookup(url) {
   if (!initialized) {
-    throw new Error('Cannot run lookup before the `setup()` function gets called');
+    throw new Error('The `lookup()` function was called before `setup()`.');
   }
-  const res = urlIndex[url];
+  if (!url) {
+    throw new Error('The `lookup()` function was called without argument.');
+  }
+
+  // URL hashes in Webref extracts are percent-encoded. Goal is to support
+  // lookup of both percent-encoded and non percent-encoded URLs. To make sure
+  // that we end up with what we need, let's force a decode (this will be a
+  // no-op if the fragment is not percent-encoded) before we re-encode.
+  let parsedUrl;
+  try {
+    parsedUrl = new URL(url);
+  }
+  catch (err) {
+    throw new Error('The `lookup()` function was called with an invalid URL.', err);
+  }
+  const decodedHash = decodeURIComponent(parsedUrl.hash).replace(/^#/, '');
+  parsedUrl.hash = encodeURIComponent(decodedHash);
+  const lookupUrl = parsedUrl.toString();
+
+  const res = urlIndex[lookupUrl.toString()];
   return structuredClone(res) ?? [];
 }

--- a/packages-auto/xref/index.js
+++ b/packages-auto/xref/index.js
@@ -117,8 +117,14 @@ export function lookup(url) {
   catch (err) {
     throw new Error('The `lookup()` function was called with an invalid URL.', err);
   }
-  const decodedHash = decodeURIComponent(parsedUrl.hash).replace(/^#/, '');
-  parsedUrl.hash = encodeURIComponent(decodedHash);
+  let decodedHash;
+  try {
+    decodedHash = decodeURIComponent(parsedUrl.hash);
+  }
+  catch {
+    decodedHash = parsedUrl.hash;
+  }
+  parsedUrl.hash = encodeURIComponent(decodedHash.replace(/^#/, ''));
   const lookupUrl = parsedUrl.toString();
 
   const res = urlIndex[lookupUrl.toString()];

--- a/test/xref/all.js
+++ b/test/xref/all.js
@@ -13,12 +13,12 @@ import { setup, lookup } from '@webref/xref';
 const scriptPath = path.dirname(fileURLToPath(import.meta.url));
 const rootFolder = path.join(scriptPath, '..', '..');
 
-describe('The @webref/xref code', function () {
+describe('The @webref/xref lookup() function', function () {
   before(function () {
     setup(rootFolder);
   });
 
-  it('can lookup a dfn', function () {
+  it('can find a dfn', function () {
     const url = 'https://html.spec.whatwg.org/multipage/webappapis.html#event-loop';
     const res = lookup(url);
     assert(res?.length, 'No dfn found');
@@ -28,7 +28,7 @@ describe('The @webref/xref code', function () {
     assert.strictEqual(entry.spec, 'html');
   });
 
-  it('can lookup a heading', function () {
+  it('can find a heading', function () {
     const url = 'https://compat.spec.whatwg.org/#css-at-rules';
     const res = lookup(url);
     assert(res?.length, 'No heading found');
@@ -38,7 +38,7 @@ describe('The @webref/xref code', function () {
     assert.strictEqual(entry.spec, 'compat');
   });
 
-  it('can lookup a dfn through a dev link', function () {
+  it('can find a dfn through a dev link', function () {
     const url = 'https://html.spec.whatwg.org/multipage/introduction.html#typographic-conventions%3Ax-that';
     const res = lookup(url);
     assert(res?.length, 'No dfn found');
@@ -48,7 +48,19 @@ describe('The @webref/xref code', function () {
     assert.strictEqual(entry.spec, 'html');
   });
 
-  it('can lookup a heading using an alternate ID', function () {
+  it('can find a dfn when the hash is not percent-encoded', function () {
+    const hash = 'typographic-conventions:x-that';
+    const baseUrl = 'https://html.spec.whatwg.org/multipage/introduction.html#';
+    const url = baseUrl + hash;
+    const res = lookup(url);
+    assert(res?.length, 'No dfn found');
+    assert.strictEqual(res[0].source, 'dfns');
+    const entry = res[0].entry;
+    assert.strictEqual(entry.links?.[0]?.href, baseUrl + encodeURIComponent(hash));
+    assert.strictEqual(entry.spec, 'html');
+  });
+
+  it('can find a heading using an alternate ID', function () {
     const fragment = 'contents';
     const url = `https://drafts.csswg.org/css-ui-4/#${fragment}`;
     const res = lookup(url);
@@ -59,7 +71,7 @@ describe('The @webref/xref code', function () {
     assert.strictEqual(entry.spec, 'css-ui-4');
   });
 
-  it('can lookup a dfn with a release URL', function () {
+  it('can find a dfn with a release URL', function () {
     const url = 'https://www.w3.org/TR/webcodecs/#videodecoder';
     const res = lookup(url);
     assert(res?.length, 'No dfn found');
@@ -73,5 +85,21 @@ describe('The @webref/xref code', function () {
     const url = 'https://compat.spec.whatwg.org/#idontexist';
     const res = lookup(url);
     assert.strictEqual(res?.length, 0);
+  });
+
+  it('throws when no URL is given', function () {
+    assert.throws(lookup, {
+      name: 'Error',
+      message: 'The `lookup()` function was called without argument.'
+    });
+  });
+
+  it('throws when the URL is invalid', function () {
+    assert.throws(function () {
+      lookup('invalid');
+    }, {
+      name: 'Error',
+      message: 'The `lookup()` function was called with an invalid URL.'
+    });
   });
 });

--- a/test/xref/all.js
+++ b/test/xref/all.js
@@ -102,4 +102,15 @@ describe('The @webref/xref lookup() function', function () {
       message: 'The `lookup()` function was called with an invalid URL.'
     });
   });
+
+  it('considers that a hash with a `%` not followed by digits is decoded', function () {
+    const hash = 'sec-%foriniteratorprototype%-object';
+    const baseUrl = 'https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#';
+    const url = baseUrl + hash;
+    const res = lookup(url);
+    assert(res?.length, 'No dfn found');
+    assert.strictEqual(res[0].source, 'dfns');
+    const entry = res[0].entry;
+    assert.strictEqual(entry.href, baseUrl + encodeURIComponent(hash));
+  });
 });


### PR DESCRIPTION
Via https://github.com/mdn/browser-compat-data/pull/23958#issuecomment-4495384695

BCD does not use URL hashes that are percent-encoded. Webref does. It seems ok to support both forms in the lookup function.

Note: this creates more cases where the `lookup()` may throw an `Error`. We may want to create a better-looking `ParameterError` at some point to make it clear to caller that these errors are due to a problem on their part. Keeping things simple for now.

This update also fixes the code that indexes URLs from `alternateIds` to percent-encode the IDs, although note that the fix is hypothetical for the time being as there aren't any alternate ID that contains characters that need to be encoded.