### PR TITLE
Rollback IDL patch of SVG spec

### DIFF
--- a/ed/idlpatches/SVG.idl.patch
+++ b/ed/idlpatches/SVG.idl.patch
@@ -1,32 +1,21 @@
-From 8b3e4cd74626412507b14e0fa5b76fc6efcbc926 Mon Sep 17 00:00:00 2001
+From 8f3ed1a11128229948e2fcad50d59a94fb267f61 Mon Sep 17 00:00:00 2001
 From: Francois Daoust <fd@tidoust.net>
-Date: Tue, 19 May 2026 13:32:47 +0200
+Date: Wed, 6 May 2026 09:18:20 +0200
 Subject: [PATCH] Fix IDL of SVG spec
 
-- HTMLHyperlinkElementUtils: https://github.com/w3c/svgwg/issues/312
-- Duplicate attribute: https://github.com/w3c/svgwg/pull/1110
+HTMLHyperlinkElementUtils: https://github.com/w3c/svgwg/issues/312
 
 Also drop `SVGPathElement`, now that SVG Paths is also being crawled, pending
 clarification of status between SVG 2 and SVG Paths.
 ---
- ed/idl/SVG.idl | 22 ++++++++++++++--------
- 1 file changed, 14 insertions(+), 8 deletions(-)
+ ed/idl/SVG.idl | 19 ++++++++++++++-----
+ 1 file changed, 14 insertions(+), 5 deletions(-)
 
 diff --git a/ed/idl/SVG.idl b/ed/idl/SVG.idl
-index 8a35bfaf50..097d7e8957 100644
+index 6edd6cac38..e8e070bb6f 100644
 --- a/ed/idl/SVG.idl
 +++ b/ed/idl/SVG.idl
-@@ -328,9 +328,6 @@ interface SVGStyleElement : SVGElement {
-   [Reflect] attribute DOMString media;
-   [Reflect] attribute DOMString title;
-   attribute boolean disabled;
--
--  // obsolete members
--  attribute DOMString type;
- };
- 
- SVGStyleElement includes LinkStyle;
-@@ -416,10 +413,6 @@ interface SVGAnimatedPreserveAspectRatio {
+@@ -415,10 +415,6 @@ interface SVGAnimatedPreserveAspectRatio {
    [SameObject] readonly attribute SVGPreserveAspectRatio animVal;
  };
  
@@ -37,7 +26,7 @@ index 8a35bfaf50..097d7e8957 100644
  [Exposed=Window]
  interface SVGRectElement : SVGGeometryElement {
    [SameObject] readonly attribute SVGAnimatedLength x;
-@@ -669,7 +662,20 @@ interface SVGAElement : SVGGraphicsElement {
+@@ -668,7 +664,20 @@ interface SVGAElement : SVGGraphicsElement {
  };
  
  SVGAElement includes SVGURIReference;
@@ -61,4 +50,3 @@ index 8a35bfaf50..097d7e8957 100644
  interface SVGViewElement : SVGElement {};
 -- 
 2.54.0
-


### PR DESCRIPTION
The duplicate attribute was fixed in the spec. We're back to the previous set of problems.