### PR TITLE
`@webref/xref`: Add specs and a few initial lookup options

### DIFF
--- a/packages-auto/xref/README.md
+++ b/packages-auto/xref/README.md
@@ -38,6 +38,83 @@ for (const url of urls) {
 
 *Note:* The function returns an array because the same URL may be used for a dfn and a heading.
 
+The `lookup()` function takes the URL to search for as first parameter. It also accepts a [lookup options](#lookup-options) object as second parameter.
+
+### Lookup options
+
+*Note:* Lookup options apply as a logical AND when combined.
+
+#### `series` option
+
+By default, the `lookup()` function assumes that the provided URL uses the nightly or release URL of a spec. Set the `series` boolean flag to find definitions and headings that match a URL that uses the [series](https://github.com/w3c/browser-specs/#series) URL of a spec.
+
+Internally, the series URL gets converted to the nightly or release URL of the spec known to be the [current spec](https://github.com/w3c/browser-specs/#seriescurrentspecification) in the series.
+
+```js
+import * as xref from '@webref/xref';
+xref.setup();
+
+// URL that targets the CSS Paged Media Module series
+const url = 'https://www.w3.org/TR/css-page/#page-selector';
+
+// Default lookup won't return anything
+const notfound = xref.lookup(url);
+
+// With the `series` flag, lookup will convert the series
+// URL to the URL of the current spec in the series. As of
+// May 2026, the current spec in the css-page series is
+// css-page-3. Returned dfn will have the URL:
+// https://www.w3.org/TR/css-page-3/#page-selector
+const found = xref.lookup(url, { series: true });
+```
+
+*Note:* The flag may be set even when the provided URL is not a series URL, lookup will just proceed as usual in this case.
+
+#### `standing` option
+
+The cross-references database contains definitions and headings from all crawled specs. The list of crawled specs in Webref matches the list of specs in [`browser-specs`](https://github.com/w3c/browser-specs) whose [`standing`](https://github.com/w3c/browser-specs/#standing) property is `"good"` or `"pending"`. For historical reasons, the list also include a few specific specs whose standing is `"discontinued"` (such as the DOM Level 2 Style spec).
+
+Set the `standing` option to one of the possible standing values to only keep results from specs whose standing match the specified one.
+
+```js
+import * as xref from '@webref/xref';
+xref.setup();
+
+// As of May 2026, the Direct Sockets proposal is "pending"
+const url = 'https://wicg.github.io/direct-sockets/#dfn-readable';
+
+// Default lookup will return a dfn
+const found = xref.lookup(url);
+
+// No result if lookup is restricted to specs in good standing
+const notfound = xref.lookup(url, { standing: 'good' });
+```
+
+#### `version` option
+
+The cross-references database contains definitions and headings from both nightly and release versions of the specs.
+
+Set the `version` option to one of `"nightly"` or `"release"` to only return results from the underlying version of a spec.
+
+```js
+import * as xref from '@webref/xref';
+xref.setup();
+
+// A URL that targets the release version of a spec
+const url = 'https://www.w3.org/TR/css-page-3/#page-selector';
+
+// Default lookup will return a dfn
+const found = xref.lookup(url);
+
+// No result if lookup is restricted to nightly versions
+const notfound = xref.lookup(url, { version: 'nightly' });
+
+// Note: This option is a convenience method for the
+// following, which achieves the exact same thing
+const same = xref.lookup(url)
+  .filter(match => match.entry.version === 'nightly');
+```
+
 ## Lookup matches
 
 A match returned by the `lookup()` function is an object with two keys: `source` and `entry`.

--- a/packages-auto/xref/index.js
+++ b/packages-auto/xref/index.js
@@ -9,7 +9,8 @@ const scriptPath = path.dirname(fileURLToPath(import.meta.url));
  */
 const xref = {
   dfns: [],
-  headings: []
+  headings: [],
+  specs: []
 };
 
 /**
@@ -83,6 +84,18 @@ export function setup(rootFolder = scriptPath) {
   if (initialized) {
     return;
   }
+  if (rootFolder === scriptPath) {
+    // We're in "package" mode, the root folder contains a `specs.json` file.
+    xref.specs = JSON.parse(fs.readFileSync(path.join(rootFolder, 'specs.json'), 'utf8'));
+  }
+  else {
+    // We're in "use crawl results" mode, the root folder won't contain a
+    // `specs.json` file, but the `ed` folder should have a crawl index with a
+    // list of specs.
+    const crawl = JSON.parse(fs.readFileSync(path.join(rootFolder, 'ed', 'index.json'), 'utf8'));
+    xref.specs = crawl.results;
+  }
+
   for (const type of ['dfns', 'headings']) {
     setupExtracts(type, rootFolder);
   }
@@ -94,11 +107,14 @@ export function setup(rootFolder = scriptPath) {
  * Lookup a URL in the loaded database
  *
  * The function returns an array of entries. Each entry is an object with a
- * `source` key set to "dfns", "headings", "links", or "alternateIds"; and a
- * `entry` key set to either a dfn object when `source` is "dfns" or "links",
- * or a heading object when `source` is "headings" or "alternateIds".
+ * `source` key set to "dfns" or "headings"; and a `entry` key set to either a
+ * dfn object when `source` is "dfns" or a heading object when `source` is
+ * "headings".
+ *
+ * The function accepts a lookup options object as second parameter that sets
+ * lookup capabilities and filters. Check the README for details.
  */
-export function lookup(url) {
+export function lookup(url, { standing, version, series } = {}) {
   if (!initialized) {
     throw new Error('The `lookup()` function was called before `setup()`.');
   }
@@ -125,8 +141,40 @@ export function lookup(url) {
     decodedHash = parsedUrl.hash;
   }
   parsedUrl.hash = encodeURIComponent(decodedHash.replace(/^#/, ''));
-  const lookupUrl = parsedUrl.toString();
+  let lookupUrl = parsedUrl.toString();
 
-  const res = urlIndex[lookupUrl.toString()];
-  return structuredClone(res) ?? [];
+  // If the series flag is set, the provided URL may also be a spec series URL,
+  // which we need to convert to the URL of the current spec in the series.
+  if (series) {
+    // Drop the hash to match spec URLs
+    const hash = parsedUrl.hash;
+    parsedUrl.hash = '';
+    const specUrl = parsedUrl.toString();
+    const spec = xref.specs.find(spec =>
+      spec.shortname === spec.series.currentSpecification &&
+      (spec.series.nightlyUrl === specUrl || spec.series.releaseUrl === specUrl)
+    );
+    if (spec) {
+      // The lookup URL matches a series URL indeed, let's change it to the URL
+      // of the current spec in the series
+      const currentUrl = new URL(
+        (spec.series.nightlyUrl === specUrl) ? spec.nightly.url : spec.release.url
+      );
+      currentUrl.hash = hash;
+      lookupUrl = currentUrl.toString();
+    }
+  }
+
+  // Look for the resulting URL and filter results as needed
+  let res = urlIndex[lookupUrl.toString()] ?? [];
+  const hasSpecFilter = standing || version;
+  if (hasSpecFilter) {
+    res = res.filter(match => {
+      const entry = match.entry;
+      const spec = xref.specs.find(spec => spec.shortname === entry.spec);
+      return (!standing || spec.standing === standing) &&
+        (!version || entry.version === version);
+    });
+  }
+  return structuredClone(res);
 }

--- a/packages-auto/xref/index.js
+++ b/packages-auto/xref/index.js
@@ -145,7 +145,7 @@ export function lookup(url, { standing, version, series } = {}) {
 
   // If the series flag is set, the provided URL may also be a spec series URL,
   // which we need to convert to the URL of the current spec in the series.
-  if (series) {
+  if (series && !urlIndex[lookupUrl.toString()]) {
     // Drop the hash to match spec URLs
     const hash = parsedUrl.hash;
     parsedUrl.hash = '';

--- a/test/xref/all.js
+++ b/test/xref/all.js
@@ -113,4 +113,56 @@ describe('The @webref/xref lookup() function', function () {
     const entry = res[0].entry;
     assert.strictEqual(entry.href, baseUrl + encodeURIComponent(hash));
   });
+
+  it('can take an option argument', function () {
+    const url = 'https://html.spec.whatwg.org/multipage/webappapis.html#event-loop';
+    const res = lookup(url, {});
+    assert(res?.length, 'No dfn found');
+    assert.strictEqual(res[0].source, 'dfns');
+    const entry = res[0].entry;
+    assert.strictEqual(entry.href, url);
+    assert.strictEqual(entry.spec, 'html');
+  });
+
+  it('can filter on the spec\'s standing', function () {
+    const url = 'https://drafts.csswg.org/css-page-4/#page-box';
+
+    const resUnfiltered = lookup(url, { standing: 'pending' });
+    assert(resUnfiltered?.length, 'No dfn found');
+    assert.strictEqual(resUnfiltered[0].source, 'dfns');
+    const entryUnfiltered = resUnfiltered[0].entry;
+    assert.strictEqual(entryUnfiltered.href, url);
+    assert.strictEqual(entryUnfiltered.spec, 'css-page-4');
+
+    const resFiltered = lookup(url, { standing: 'good' });
+    assert.strictEqual(resFiltered?.length, 0, 'Dfn was not filtered');
+  });
+
+  it('can filter on the spec\'s version', function () {
+    const url = 'https://www.w3.org/TR/css-page-3/#page-selector';
+
+    const resUnfiltered = lookup(url, { version: 'release' });
+    assert(resUnfiltered?.length, 'No dfn found');
+    assert.strictEqual(resUnfiltered[0].source, 'dfns');
+    const entryUnfiltered = resUnfiltered[0].entry;
+    assert.strictEqual(entryUnfiltered.href, url);
+    assert.strictEqual(entryUnfiltered.spec, 'css-page-3');
+
+    const resFiltered = lookup(url, { version: 'nightly' });
+    assert.strictEqual(resFiltered?.length, 0, 'Dfn was not filtered');
+  });
+
+  it('can lookup series URLs', function () {
+    const url = 'https://www.w3.org/TR/css-page/#page-selector';
+
+    const resUnfiltered = lookup(url, { series: true });
+    assert(resUnfiltered?.length, 'No dfn found');
+    assert.strictEqual(resUnfiltered[0].source, 'dfns');
+    const entryUnfiltered = resUnfiltered[0].entry;
+    assert.strictEqual(entryUnfiltered.href, 'https://www.w3.org/TR/css-page-3/#page-selector');
+    assert.strictEqual(entryUnfiltered.spec, 'css-page-3');
+
+    const resFiltered = lookup(url, { series: false });
+    assert.strictEqual(resFiltered?.length, 0, 'Dfn was not filtered');
+  });
 });

--- a/tools/release-autopackages.js
+++ b/tools/release-autopackages.js
@@ -71,11 +71,9 @@ async function releaseXrefPackage(minorBump) {
       const srcDir = path.join(version, type);
       const srcFiles = await fs.readdir(srcDir);
       for (const file of srcFiles) {
-        if (file.endsWith(`.json`)) {
-          const spec = specs.find(s => `${s.shortname}.json` === file);
-          if (spec) {
-            await fs.copyFile(path.join(srcDir, file), path.join(dstDir, file));
-          }
+        if (file.endsWith(`.json`) &&
+            specs.find(s => `${s.shortname}.json` === file)) {
+          await fs.copyFile(path.join(srcDir, file), path.join(dstDir, file));
         }
       }
       console.log(`- ${type} extracts copied to ${dstDir}`);

--- a/tools/release-autopackages.js
+++ b/tools/release-autopackages.js
@@ -15,6 +15,8 @@ import { execSync } from "node:child_process";
 import { npmPublish } from "@jsdevtools/npm-publish";
 import { createFolderIfNeeded, loadJSON } from "./utils.js";
 
+import crawl from "../ed/index.json" with { type: "json" };
+
 
 /**
  * Release package at the requested version.
@@ -28,6 +30,30 @@ async function releaseXrefPackage(minorBump) {
 
   const packageFolder = path.join('packages-auto', 'xref');
   await createFolderIfNeeded(packageFolder);
+
+  // Prepare the list of specs from the crawl's result, keeping information
+  // that we may use for filtering (or display purpose). This list is
+  // essentially web-specs.
+  // Note: we'll use the "ed" list, which should be more up-to-date than the
+  // "tr" one, and we'll ignore "tr" extracts that cannot be mapped to a spec.
+  const specs = crawl.results.map(result => Object.assign({
+    url: result.url,
+    seriesComposition: result.seriesComposition,
+    shortname: result.shortname,
+    series: result.series,
+    categories: result.categories,
+    organization: result.organization,
+    groups: result.groups,
+    nightly: result.nightly,
+    release: result.release,
+    title: result.title,
+    shortTitle: result.shortTitle,
+    standing: result.standing,
+    crawled: result.crawled,
+    date: result.date
+  }));
+  await fs.writeFile(path.join(packageFolder, 'specs.json'), JSON.stringify(specs, null, 2), 'utf8');
+  console.log('- wrote the list of specs');
 
   for (const version of ['ed', 'tr']) {
     await createFolderIfNeeded(path.join(packageFolder, version));
@@ -46,7 +72,10 @@ async function releaseXrefPackage(minorBump) {
       const srcFiles = await fs.readdir(srcDir);
       for (const file of srcFiles) {
         if (file.endsWith(`.json`)) {
-          await fs.copyFile(path.join(srcDir, file), path.join(dstDir, file));
+          const spec = specs.find(s => `${s.shortname}.json` === file);
+          if (spec) {
+            await fs.copyFile(path.join(srcDir, file), path.join(dstDir, file));
+          }
         }
       }
       console.log(`- ${type} extracts copied to ${dstDir}`);


### PR DESCRIPTION
Via https://github.com/mdn/browser-compat-data/pull/23958#issuecomment-4495384695

Any specific lookup rule requires shipping web-specs within the package, which is what this update does. To make sure that the list matches the data, the list of specs is rather built from the crawl index.

The `lookup()` function may now take an optional object with lookup options as second argument. The following options are supported:

- `standing`: only keep results from specs that have the specific standing. Standing should be `"good"`, `"pending"` or `"discontinued"` (most discontinued specs aren't crawled, but some still are for historical reasons).
- `version`: only keep results from the nightly or release version of the specs. Must be `"nightly"` or `"release"`.
- `series`: accept series URLs. Internally, the URL will only match if the fragment exists in the spec that is known to be the current spec in the series.

*Note:* the code does not yet provide any way to access the list of specs itself. That's another thing that could be added later on if the need arises. For example, this would be useful for callers should they need to create custom filtering logic.