### PR TITLE
Add CSS syntax patch for `@route` defined in `css-navigation-1`

### DIFF
--- a/ed/csspatches/syntax-patches.js
+++ b/ed/csspatches/syntax-patches.js
@@ -101,6 +101,11 @@ export default {
     "<counter-name>": "<custom-ident>"
   },
 
+  // https://drafts.csswg.org/css-navigation-1/#at-ruledef-route
+  "css-navigation-1": {
+    "@route": "<route-rule>"
+  },
+
   // https://drafts.csswg.org/css-overflow-5/#typedef-scroll-button-direction
   "css-overflow-5": {
     "<scroll-button-direction>": {


### PR DESCRIPTION
The association between the at-rule and the `<route-rule>` production is defined in prose:
https://drafts.csswg.org/css-navigation-1/#at-ruledef-route