### PR TITLE
Add patch for ed/idl/webxr-webgpu-binding.idl

### DIFF
--- a/ed/idlpatches/webxr-webgpu-binding.idl.patch
+++ b/ed/idlpatches/webxr-webgpu-binding.idl.patch
@@ -1,0 +1,30 @@
+From 513a7389a25030ed557d31185c9034d0b93a3ff9 Mon Sep 17 00:00:00 2001
+From: Francois Daoust <fd@tidoust.net>
+Date: Fri, 17 Jul 2026 11:09:16 +0200
+Subject: [PATCH] Drop `xrCompatible` option
+
+The option has already been upstreamed to WebGPU. Tracking issue to get the
+definition removed from `webxr-webgpu-binding`:
+https://github.com/immersive-web/webxr-webgpu-binding/issues/35
+---
+ ed/idl/webxr-webgpu-binding.idl | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/ed/idl/webxr-webgpu-binding.idl b/ed/idl/webxr-webgpu-binding.idl
+index 85a1b6bf0a..03d38d68a7 100644
+--- a/ed/idl/webxr-webgpu-binding.idl
++++ b/ed/idl/webxr-webgpu-binding.idl
+@@ -3,10 +3,6 @@
+ // (https://github.com/w3c/webref)
+ // Source: WebXR/WebGPU Binding Module - Level 1 (https://immersive-web.github.io/webxr-webgpu-binding/)
+ 
+-partial dictionary GPURequestAdapterOptions {
+-    boolean xrCompatible = false;
+-};
+-
+ [Exposed=(Window), SecureContext]
+ interface XRGPUBinding {
+   constructor(XRSession session, GPUDevice device);
+-- 
+2.54.0
+


### PR DESCRIPTION
Drop the `xrCompatible` option that has already been upstreamed to WebGPU.