### PR TITLE
Add CSS syntax patch for `<view-transition-type>`

### DIFF
--- a/ed/csspatches/syntax-patches.js
+++ b/ed/csspatches/syntax-patches.js
@@ -160,6 +160,11 @@ export default {
     "<integer>": "<number-token>"
   },
 
+  // https://drafts.csswg.org/css-view-transitions-2/#typedef-view-transition-type
+  "css-view-transitions-2": {
+    "<view-transition-type>": "<custom-ident>"
+  },
+
   // https://drafts.csswg.org/css2/#value-def-shape
   "CSS2": {
     "<shape>": "rect(<top>, <right>, <bottom>, <left>)"


### PR DESCRIPTION
## Summary
- Add a CSS syntax patch so `<view-transition-type>` gets an explicit `<custom-ident>` value during curation.
- The type is defined only in prose in css-view-transitions-2 (any `<custom-ident>` other than `none`, and not starting with `-ua-`), so Reffy cannot extract a formal syntax.

Fixes #1986.

## Test plan
- [x] `npm run curate` applies the `css-view-transitions-2` syntax patch
- [x] Curated `css-view-transitions.json` has `"value": "<custom-ident>"` on `<view-transition-type>`
- [ ] CI curate + test jobs pass on the PR