### PR TITLE
Regenerate patch for ed/idl/css-fonts.idl

### DIFF
--- a/ed/idlpatches/css-fonts.idl.patch
+++ b/ed/idlpatches/css-fonts.idl.patch
@@ -1,6 +1,6 @@
-From 4de26487377913639b78778d935d0ee2fb291b5e Mon Sep 17 00:00:00 2001
+From 45d480ea5232a4a6d9edcd1664e89c82e4451b6f Mon Sep 17 00:00:00 2001
 From: Francois Daoust <fd@tidoust.net>
-Date: Mon, 5 Jan 2026 08:56:58 +0100
+Date: Mon, 17 Aug 2026 18:31:50 +0200
 Subject: [PATCH] Drop interfaces redefined in css-fonts-5
 
 The `CSSFontFaceDescriptors` and `CSSFontFaceRule` interfaces get redefined in
@@ -11,7 +11,7 @@ CSS Fonts Level 5 becomes a full spec.
  1 file changed, 38 deletions(-)
 
 diff --git a/ed/idl/css-fonts.idl b/ed/idl/css-fonts.idl
-index c1e1a62880..3d90de6ab5 100644
+index 0a2136fdbd..b925d4d6a6 100644
 --- a/ed/idl/css-fonts.idl
 +++ b/ed/idl/css-fonts.idl
 @@ -3,44 +3,6 @@
@@ -57,8 +57,8 @@ index c1e1a62880..3d90de6ab5 100644
 -};
 -
  partial interface CSSRule {
-     const unsigned short FONT_FEATURE_VALUES_RULE = 14;
-   };
+   const unsigned short FONT_FEATURE_VALUES_RULE = 14;
+ };
 -- 
-2.52.0
+2.55.0
 


### PR DESCRIPTION
Indentation of a closing `}` was fixed in an IDL block, invalidating the previous patch. No change otherwise.

Note: this won't be enough to fix curation.