### PR TITLE
Add backrefs extracts per spec during curation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ More often than not, released versions of specifications are much older than the
 
 The following subfolders in the `curated` branch contain individual machine-readable JSON or text files generated from specifications:
 
+- [`ed/backrefs`](https://github.com/w3c/webref/tree/curated/ed/backrefs): Back references to definitions of a specification from other specifications. One file per specification. This is a curated, derived view built from `dfns` and `links` extracts.
 - [`ed/cddl`](https://github.com/w3c/webref/tree/curated/ed/cddl): CDDL modules. If the specification defines a single CDDL module, one file gets created for the specification. If it defines multiple CDDL modules, one file gets created per CDDL module, plus one file named `[shortname]-all.cddl` with all CDDL definitions.
 - [`ed/css`](https://github.com/w3c/webref/tree/curated/ed/css): CSS terms (properties, descriptors, value spaces). One file per specification [series](https://github.com/w3c/browser-specs/#series).
 - [`ed/dfns`](https://github.com/w3c/webref/tree/curated/ed/dfns): `<dfn>` terms, along with metadata such as linking text, access level, namespace. One file per specification.
@@ -73,6 +74,7 @@ Data curation brings the following guarantees.
 
 The consolidated `ed/css.json` file, released in the `@webref/css` package, comes with the following guarantees:
 
+- The file follows the [relevant JSON schema](https://github.com/w3c/reffy/blob/main/schemas/postprocessing/css.json) in the version of Reffy that was used to crawl the specs.
 - All syntax values (the `syntax` keys) can be parsed by the version of [CSSTree](https://github.com/csstree/csstree) set in `peerDependencies` in `package.json`.
 - Feature names (the `name` keys) are unique per type provided that the `for` key is also taken into account for functions and types.
 - CSS features targeted by `for`, `legacyAliasOf`, `longhands` and `resetLonghands` keys are guaranteed to exist in the package.
@@ -81,6 +83,7 @@ The consolidated `ed/css.json` file, released in the `@webref/css` package, come
 
 The consolidated file is generated from curated extracts in the `ed/css` folder. These extracts, released in the `@webref/css` package until version 7, come with the following guarantees:
 
+- All extracts follow the [relevant JSON schema](https://github.com/w3c/reffy/blob/main/schemas/files/extracts/css.json) in the version of Reffy that was used to crawl the specs.
 - All values in CSS files can be parsed by the version of [CSSTree](https://github.com/csstree/csstree) used in `peerDependencies` in `package.json`.
 - No duplicate definitions of entries in CSS files provided that CSS extracts of [delta specs](https://github.com/w3c/browser-specs/#seriescomposition) are not taken into account (such extracts end with `-n.json`, where `n` is a level number). The term "entries" includes CSS properties, at-rules, selectors, types and functions. Please note that specs may still extend entries defined elsewhere (to define new values for CSS properties, or new selectors for at-rules).
 - CSS extracts contain a base definition of all CSS properties that get extended by other CSS property definitions (those for which `newValues` is set).
@@ -88,6 +91,7 @@ The consolidated file is generated from curated extracts in the `ed/css` folder.
 
 ### Elements extracts
 
+- All extracts follow the [relevant JSON schema](https://github.com/w3c/reffy/blob/main/schemas/files/extracts/elements.json) in the version of Reffy that was used to crawl the specs.
 - All Web IDL interfaces referenced by elements exist in Web IDL extracts.
 - All elements link back to their definition in the spec.
 
@@ -95,6 +99,7 @@ The consolidated file is generated from curated extracts in the `ed/css` folder.
 
 The consolidated `ed/events.json` file, released in the `@webref/events` package, comes with the following guarantees:
 
+- The file follows the [relevant JSON schema](https://github.com/w3c/reffy/blob/main/schemas/postprocessing/events.json) in the version of Reffy that was used to crawl the specs.
 - All events have a `type` attribute that match the name of the event
 - All events have a `interface` attribute to describe the interface used by the Event. The Web IDL interface exists in the latest version of the [`@webref/idl` package](https://www.npmjs.com/package/@webref/idl) at the time the `@webref/events` package is released, and represents an actual interface (i.e. not a mixin).
 - All events have a `targets` attribute with a non-empty list of target interfaces on which the event may fire. All Web IDL interfaces in the list exist in the latest version of the [`@webref/idl` package](https://www.npmjs.com/package/@webref/idl) at the time the `@webref/events` package is released, and represent an actual interface (i.e. not a mixin).
@@ -109,6 +114,18 @@ The consolidated `ed/events.json` file, released in the `@webref/events` package
 - All CDDL files pass CDDL analysis by the version of [Strudy](https://github.com/w3c/strudy) referenced in `package.json`. Said differently, all CDDL files can be parsed by the version of [cddlparser](https://github.com/tidoust/cddlparser) referenced by Strudy.
 
 The CDDL extracts are not released in an NPM package for the time being.
+
+### Backrefs extracts
+
+- All extracts follow the [relevant JSON schema](https://github.com/w3c/reffy/blob/main/schemas/postprocessing/backrefs.json) in the version of Reffy that was used to crawl the specs.
+- The extracts contain both terms defined as private and public.
+- Every `backrefs[]` entry corresponds to a definition that exists in the defining spec's `dfns` extract (matched by `href`).
+- `id`, `href`, `linkingText`, `type`, `for`, and `access` are copied from that definition so the extract is usable on its own.
+- `referencedBy` is a non-empty list of distinct referencing specifications. The defining specification itself never appears in `referencedBy`.
+- Every `referencedBy[].shortname` identifies a specification present in the crawl (and thus listed in `ed/index.json`).
+
+The backrefs extracts are not released in an NPM package for the time being.
+
 
 ## Known consumers
 

--- a/test/backrefs/all.js
+++ b/test/backrefs/all.js
@@ -1,0 +1,107 @@
+/**
+ * Test per-spec back-reference extracts.
+ *
+ * The tests run against the curated view.
+ */
+
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadJSON } from '../../tools/utils.js';
+
+const scriptPath = path.dirname(fileURLToPath(import.meta.url));
+const curatedFolder = path.join(scriptPath, '..', '..', 'curated');
+const backrefsFolder = path.join(curatedFolder, 'backrefs');
+
+describe('The curated view of backrefs extracts', async () => {
+  const index = await loadJSON(path.join(curatedFolder, 'index.json'));
+  assert.ok(index, 'curated/index.json must exist (run npm run curate first)');
+
+  const shortnames = new Set(index.results.map(s => s.shortname));
+  const specsWithBackrefs = index.results.filter(s => s.backrefs);
+
+  it('only creates files for specs that appear in the crawl index', async () => {
+    let files = [];
+    try {
+      files = await fs.readdir(backrefsFolder);
+    }
+    catch (err) {
+      if (err.code === 'ENOENT') {
+        assert.fail('curated/backrefs folder is missing (run npm run curate first)');
+      }
+      throw err;
+    }
+    for (const file of files) {
+      if (!file.endsWith('.json')) {
+        continue;
+      }
+      const shortname = file.replace(/\.json$/, '');
+      assert.ok(
+        shortnames.has(shortname),
+        `Found backrefs file for unknown shortname ${shortname}`
+      );
+    }
+  });
+
+  it('copies identifying dfn fields including for and access', async () => {
+    for (const spec of specsWithBackrefs) {
+      const data = await loadJSON(path.join(curatedFolder, spec.backrefs));
+      const dfns = await loadJSON(path.join(curatedFolder, spec.dfns));
+      for (const term of data.backrefs) {
+        assert.ok(term.id, `${spec.backrefs} entry is missing id`);
+        assert.ok(term.href, `${spec.backrefs} entry is missing href`);
+        assert.ok(Array.isArray(term.linkingText), `${term.href} linkingText is not an array`);
+        assert.ok(term.type, `${term.href} is missing type`);
+        assert.ok(Array.isArray(term.for), `${term.href} for is not an array`);
+        assert.ok(
+          term.access === 'public' || term.access === 'private',
+          `${term.href} has unexpected access ${term.access}`
+        );
+        const dfn = dfns.dfns.find(t => t.href === term.href);
+        assert.ok(dfn, `${spec.backrefs} entry ${term.href} does not exist in the dfns extract`);
+        assert.equal(term.id, dfn.id, `${spec.backrefs} entry ${term.href} should have the same id as the dfn`);
+        assert.deepEqual(term.linkingText, dfn.linkingText, `${spec.backrefs} entry ${term.href} should have the same linking texts as the dfn`);
+        assert.equal(term.type, dfn.type, `${spec.backrefs} entry ${term.href} should have the same type as the dfn`);
+        assert.deepEqual(term.for, dfn.for, `${spec.backrefs} entry ${term.href} should have the same scope as the dfn`);
+        assert.equal(term.access, dfn.access, `${spec.backrefs} entry ${term.href} should have the same access level as the dfn`);
+      }
+    }
+  });
+
+  it('lists only external referrers that exist in the crawl index', async () => {
+    for (const spec of specsWithBackrefs) {
+      const data = await loadJSON(path.join(curatedFolder, spec.backrefs));
+      assert.ok(data.backrefs.length > 0, `${spec.backrefs} should not be empty`);
+      for (const term of data.backrefs) {
+        assert.ok(term.referencedBy.length > 0, `${term.href} has no referrers`);
+        for (const ref of term.referencedBy) {
+          assert.ok(shortnames.has(ref.shortname), `Unknown referrer ${ref.shortname}`);
+          assert.notEqual(
+            ref.shortname,
+            spec.shortname,
+            `${term.href} lists the defining spec as a referrer`
+          );
+          assert.ok(ref.title, `Referrer ${ref.shortname} is missing a title`);
+          assert.ok(ref.url, `Referrer ${ref.shortname} is missing a url`);
+        }
+      }
+    }
+  });
+
+  it('records Fetch as referencing Streams ReadableStream', async () => {
+    const streams = specsWithBackrefs.find(s => s.shortname === 'streams');
+    assert.ok(streams, 'streams spec should have a backrefs extract');
+    const data = await loadJSON(path.join(curatedFolder, streams.backrefs));
+    const readableStream = data.backrefs.find(t =>
+      t.id === 'readablestream' ||
+      t.linkingText?.includes('ReadableStream')
+    );
+    assert.ok(readableStream, 'ReadableStream should appear in streams backrefs');
+    assert.ok(
+      readableStream.referencedBy.some(r => r.shortname === 'fetch'),
+      'Fetch should reference Streams ReadableStream'
+    );
+  });
+});

--- a/tools/prepare-curated.js
+++ b/tools/prepare-curated.js
@@ -137,7 +137,7 @@ async function prepareCurated(rawFolder, curatedFolder) {
   await crawlSpecs({
     useCrawl: curatedFolder,
     output: curatedFolder,
-    post: ['idlparsed', 'idlnames', 'events', 'cssmerge'],
+    post: ['idlparsed', 'idlnames', 'events', 'cssmerge', 'backrefs'],
     quiet: true
   });
   console.log('- done');


### PR DESCRIPTION
This leverages the new backrefs post-processing module exposed by Reffy to create backrefs extracts per spec. The update reuses content prepared by @DevOladobe in #1997.

The README now mentions the backrefs extracts as well, along with a list of guarantees, enforced by the tests.

Note that I also used this opportunity to link back to the relevant JSON schema that all curated data files are guaranteed to follow. For some reason, that wasn't specified anywhere.

This will produce ~10.4MB of data in 305 new extracts in a `backrefs` folder.

Tracking issue: #1934.