### PR TITLE
Allow Puppeteer's post-install script by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "test-idl": "node --test --test-reporter=spec \"test/idl/*.js\""
   },
   "allowScripts": {
-    "puppeteer@25.3.0": true
+    "puppeteer": true
   }
 }


### PR DESCRIPTION
Npm now defaults to blocking post-install scripts of dependencies. This adds Puppeteer (any version) to the allow-list as described in: https://pptr.dev/troubleshooting#blocked-install-scripts