### PR TITLE
Prefer `css-sizing` over `css-logical` to resolve duplicates

### DIFF
--- a/tools/drop-css-property-duplicates.js
+++ b/tools/drop-css-property-duplicates.js
@@ -36,9 +36,11 @@ const supersededBy = {
 
   // https://github.com/w3c/csswg-drafts/issues/6434#issuecomment-877447360
   // https://drafts.csswg.org/css-borders-4/#level-changes
+  // https://github.com/w3c/csswg-drafts/issues/10189
   'css-logical': [
     'css-position',
-    'css-borders'
+    'css-borders',
+    'css-sizing'
   ],
 
   // See https://github.com/w3c/csswg-drafts/issues/6435


### PR DESCRIPTION
Some properties defined in `css-logical-1` got duplicated in `css-sizing-3`, see: https://github.com/w3c/csswg-drafts/issues/10189

This makes curation logic prefer `css-sizing-3` definitions so that curation correctly drops duplicate definitions.

Note: This should fix the curation step. CI tests will still fail due to a couple of hiccups in the events space. That's orthogonal to the problem at hand.